### PR TITLE
Scaling of the number of angles at low amplitudes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# SixDesk
-My development copy of sixdesk

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# SixDesk
+My development copy of sixdesk

--- a/sixjobs/dorun_mad6t
+++ b/sixjobs/dorun_mad6t
@@ -172,7 +172,7 @@ do
     rm -rf $sixtrack_input/fort.$f"_"$i.gz
   done
   sed -e 's?%NPART?'$bunch_charge'?g' \
-      -e 's?%EMIT_BEAM?'$emit_beam'?g' \
+      -e 's?%EMIT_BEAM?'$emit_beam'*1e-6?g' \
       -e 's?%SEEDSYS?'$i'?g' \
       -e 's?%SEEDRAN?'$i'?g' $filejob.mask > $filejob."$i"
 

--- a/sixjobs/run_six
+++ b/sixjobs/run_six
@@ -1161,6 +1161,17 @@ do
 
         k=$kinil
         AngleStep=`gawk 'END{a=90/('$kmaxl'+1);print a}' /dev/null`
+
+        scaled_kstep=$kstep
+        if [ "$reduce_angs_with_aplitude" -eq 1 ] ;then
+          if [ "$ampstart" -gt 0.3 ] ;then
+            ang_scaling_factor=`gawk 'END{a='$ampfinish'/'$ampstart';print a}' /dev/null`
+          else
+            ang_scaling_factor=`gawk 'END{a='$ampfinish'/0.3;print a}' /dev/null`
+          fi
+          scaled_kstep=`gawk 'END{a='$kstep'*'$ang_scaling_factor';print a}' /dev/null`
+        fi
+
         while test "$k" -le "$kendl"
         do
           Angle=`gawk 'END{a='$AngleStep'*'$k';print a}' /dev/null`
@@ -1174,7 +1185,6 @@ do
           sixdeskrundir
           Rundir=$rundirname
 #MACRO myrundir
- 
           #
           if [ -d "$tree"/"$Rundir" ] ;then
             if [ -s "$tree"/"$Rundir"/fort.10.gz ] ;then
@@ -1420,7 +1430,7 @@ do
             fi
           fi
           # End of if NOT a Rundir already
-          k=`expr $k + $kstep`
+          k=`gawk 'END{a='$k'+'$scaled_kstep'; print a}' /dev/null`
         done
         # end of loop over angles
         ampstart=`expr $ampstart + $ampincl`

--- a/sixjobs/scripts/dorun_mad6t
+++ b/sixjobs/scripts/dorun_mad6t
@@ -171,7 +171,7 @@ do
     rm -rf $sixtrack_input/fort.$f"_"$i.gz
   done
   sed -e 's?%NPART?'$bunch_charge'?g' \
-      -e 's?%EMIT_BEAM'$emit_beam'?g' \
+      -e 's?%EMIT_BEAM'$emit_beam'*1e-6?g' \
       -e 's?%SEEDSYS?'$i'?g' \
       -e 's?%SEEDRAN?'$i'?g' $filejob.mask > $filejob."$i"
 

--- a/sixjobs/scripts/mydorun_mad6t
+++ b/sixjobs/scripts/mydorun_mad6t
@@ -76,7 +76,7 @@ do
     rm -rf $sixtrack_input/fort.$f"_"$i.gz
   done
   sed -e 's?%NPART?'$bunch_charge'?g' \
-      -e 's?%EMIT_BEAM'$emit_beam'?g' \
+      -e 's?%EMIT_BEAM'$emit_beam'*1e-6?g' \
       -e 's?%SEEDSYS?'$i'?g' \
       -e 's?%SEEDRAN?'$i'?g' $filejob.mask > $filejob."$i"
 

--- a/sixjobs/sixdeskenv
+++ b/sixjobs/sixdeskenv
@@ -226,6 +226,9 @@ then
           # and set up the LSF job type and queue
   export lsfq=$longlsfq
   export lsfjobtype=sixtracking
+
+  #reduce angle steps at small angles, achieving a constant density painting of the phase space
+  export reduce_angs_with_aplitude=0
 fi  
 
 #da parameters 


### PR DESCRIPTION
I added a flag in sixdeskenv to enable the reduction of steps in angles at low amplitude, thus achieving a constant density population of the phase space, reducing the CPU time spent at small amplitudes. This is particularly useful for FMA studies. The so-produced tracking data are successfully analysed with sixdeskdb.
The scaling is achieved by recomputing kstep at each amplitude.

I also added a conversion factor (um -> m) when substituting the beam_emittance in the mask.
