### PR TITLE
improvements in handling the xing angle

### DIFF
--- a/sixjobs/control_files/fort.3.mother1_col
+++ b/sixjobs/control_files/fort.3.mother1_col
@@ -30,8 +30,8 @@ SYNCHROTRON OSCILLATIONS--------'PLACE AFTER TRACKING PARAMETERS'-------
 NEXT
 BEAM
 %bunch_charge   %emit_beam  %emit_beam  0.7700e-01  1.1000e-04  1  %ibtype 1 0
-bb_ho5b1_0 5  %xing 0.0
-bb_ho1b1_0 5 -%xing 1.5707963268
+/ bb_ho5b1_0 5  %xing 0.0
+/ bb_ho1b1_0 5 -%xing 1.5707963268
 NEXT
 ITERATION-ACCURACY------------------------------------------------------
        50 1D-12 1D-15

--- a/sixjobs/dorun_mad6t
+++ b/sixjobs/dorun_mad6t
@@ -133,11 +133,18 @@ else
 #MACRO myexit
 
 fi
-xing_rad=$(echo $xing*.000001 | bc)
 sed -e 's?%pmass?'$pmass'?g' \
     -e 's?%emit_beam?'$emit_beam'?g' \
-    -e 's?%xing?'$xing_rad'?g' \
     $sixdeskhome/control_files/fort.3.mother1_${runtype} > $sixtrack_input/fort.3.mother1.tmp
+xing_rad=0
+if [ -n "${xing}" ] ; then 
+    # variable is defined
+    xing_rad=`echo "$xing" | awk '{print ($1*1E-06)}'`
+    echo " --> crossing defined: $xing ${xing_rad}"
+    sed -i -e 's?%xing?'$xing_rad'?g' \
+  	   -e 's?/ bb_ho5b1_0?bb_ho5b1_0?g' \
+	   -e 's?/ bb_ho1b1_0?bb_ho5b1_0?g' $sixtrack_input/fort.3.mother1.tmp
+fi
 
 cp $sixdeskhome/control_files/fort.3.mother2_${runtype}${appendbeam} $sixtrack_input/fort.3.mother2.tmp
 # Clear the flag for check_mad6t

--- a/sixjobs/sixdeskenv
+++ b/sixjobs/sixdeskenv
@@ -118,8 +118,9 @@ export kstep=1
 export emit=3.75
 export emit_beam=$emit
 
-#Crossing angle for substitution in mask and mother file
-export xing=185
+# Crossing angle for substitution in mask and mother file
+# uncomment it, to make it operational
+# export xing=185
 
 # e0 gamma
 if test $runtype = "inj"


### PR DESCRIPTION
   * corrected a bug: the original version of the code:
         xing_rad=$(echo $xing*.000001 | bc)
     was giving an error (lxplus):
         (standard_in) 1: syntax error
     changed to awk, it works fine;
   * defining the xing variable in sixdeskenv activates the feature;
   * bblenses are by default commented out; in case the xing variable is
     defined, the actual angle in rad is re-computed and substituted in
     fort.3 mother files, plus the bb lens are commented out;