### PR TITLE
Update monitoring scripts

### DIFF
--- a/boinc_software/monitor-boinc-server/README.md
+++ b/boinc_software/monitor-boinc-server/README.md
@@ -18,7 +18,9 @@ Folder containing material for monitoring the activity of/on the BOINC server. A
    * `monitorBoincServer.sh`: parses the BOINC status page and updates daily plots (bash wrapper);
    * `monitorBoincServerDailyArchive.sh`: archives daily data and updated monthly plots;
    * `parseHTML.py`: parser of BOINC status page;
+   * `parseStudyStates.py`: parser of queries to BOINC prodution DB to save table of progress;
    * `plotData.gnu`: plots daily data;
+   * `queryStudies.sh`: queries the BOINC production DB to get an idea of the current status of studies;
 
 ## `general-activity/archive`
 This folder contains past data, archived by months.
@@ -52,13 +54,19 @@ evince general-activity/status_2019-04-30.pdf &
 # please change the year-month pair according to your needs
 evince general-activity/archive/2018-03/status_2018-03.pdf &
 ```
-   * for a any desired time range:
+   * for a desired time range:
 ```
 cd general-activity/archive
 # please modify plotData_restart.gnu according to your needs
 gnuplot plotData_restart.gnu
 eog ../../boincStatus/serverOverview.png
 # please ll ../../boincStatus/ to see all available plots
+```
+
+To visulise state of studies:
+```
+# please replace HEL with a string identifying the desired studies
+grep -e '#' -e HEL studies.txt
 ```
 
 To visulise submission/assimilation on BOINC:
@@ -91,4 +99,10 @@ An example of acrontab jobs:
 15 0 * * * lxplus.cern.ch cd /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/monitor-boinc-server/submissions ; ./monitorSubmissions.sh yesterday >> monitorSubmissions.log 2>&1 ; ./monitorSubmissionsDailyArchive.sh >> monitorSubmissions.log 2>&1
 # assimilator getting stuck
 1,6,11,16,21,26,31,36,41,46,51,56 * * * * lxplus.cern.ch cd /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/monitor-boinc-server/general-activity ; ./monitorAssimilatorTimeStamp.sh >> /dev/null 2>&1
+#
+# update summary plots monitoring BOINC:
+35 2,8,14,20 * * * lxplus.cern.ch cd /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/monitor-boinc-server/boincStatus ; ./updatePlots.sh >> updatePlots.log 2>&1
+#
+# query the BOINC production DB and get current status of studies
+24 * * * * lxplus.cern.ch cd /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/monitor-boinc-server/general-activity ; ./queryStudies.sh >> queryStudies.sh.log 2>&1
 ```

--- a/boinc_software/monitor-boinc-server/general-activity/archive/plotData_period.gnu
+++ b/boinc_software/monitor-boinc-server/general-activity/archive/plotData_period.gnu
@@ -1,4 +1,4 @@
-period='2019-05'
+period='2019-06'
 iFileName='server_status_'.period
 
 # changes in status page:

--- a/boinc_software/monitor-boinc-server/general-activity/archive/plotData_restart.gnu
+++ b/boinc_software/monitor-boinc-server/general-activity/archive/plotData_restart.gnu
@@ -12,15 +12,15 @@ restaFile='../assimilatorRestart.txt'
 set xdata time
 set timefmt '%Y-%m-%d %H:%M:%S'
 # set format x '%b %Y'
-# set format x '%Y-%m-%d'
-set format x '%Y-%m-%d %H:%M'
+set format x '%Y-%m-%d'
+# set format x '%Y-%m-%d %H:%M'
 # set xtics 365.2425 / 12 * 24 * 3600 rotate by 90 right
-set xtics 3600*12 rotate by 90 right
+set xtics 3600*24 rotate by 90 right
 set grid xtics lt 0 lw 1
 # tMin=strptime("%Y-%m-%d %H:%M:%S","2017-02-01 00:00:00")
 # tMin=strptime("%Y-%m-%d %H:%M:%S","2017-06-15 00:00:00")
-tMin=strptime("%Y-%m-%d %H:%M:%S","2019-04-29 00:00:00")
-tMax=strptime("%Y-%m-%d %H:%M:%S","2019-05-20 23:59:59")
+tMin=strptime("%Y-%m-%d %H:%M:%S","2019-05-01 00:00:00")
+tMax=strptime("%Y-%m-%d %H:%M:%S","2019-07-01 00:00:00")
 set xrange [tMin:tMax]
 ybar=300
 M=0.1
@@ -107,7 +107,7 @@ set ytics mirror tc rgb 'black'
 unset y2label
 unset y2tics
 set grid xtics ytics lt 0 lw 1 lc rgb 'black'
-set yrange [0:125]
+set yrange [70:145]
 plot \
      '< cat 2019-??/server_status_????-??.dat' index 0 using 1:($16/1000) with linespoints pt 7 ps 1 lt 1 lw 1 lc rgb 'red' notitle
 set yrange [*:*]

--- a/boinc_software/monitor-boinc-server/general-activity/archive/plotPeriod.sh
+++ b/boinc_software/monitor-boinc-server/general-activity/archive/plotPeriod.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-period='2019-05'
+period='2019-06'
 toolsdir=`dirname $0`
 
 # create temporary period files

--- a/boinc_software/monitor-boinc-server/general-activity/monitorAssimilatorTimeStamp.sh
+++ b/boinc_software/monitor-boinc-server/general-activity/monitorAssimilatorTimeStamp.sh
@@ -16,13 +16,13 @@ presTime=`echo "${presTime}" | awk '{print ($2,$3)}' | cut -d\. -f1`
 presUpdate=0
 
 if [ -e ${lastMtimeFile} ] ; then
-    lastTime=`cat ${lastMtimeFile} | head -1`
-    lastUpdate=`cat ${lastMtimeFile} | head -2 | tail -1`
+    lastTime=`head -1 ${lastMtimeFile}`
+    lastUpdate=`head -2 ${lastMtimeFile} | tail -1`
     if [ "${presTime}" == "${lastTime}" ] ; then
 	if [ ${lastUpdate} -eq 0 ] ; then
 	    # first time that the assimilator log does not get updated
 	    echo "assimilator stuck: ${presTime}"
-	    echo "${presTime}" >> ${logFilesPath}/assimilatorStuck.txt
+	    echo "${presTime}" | tee -a ${logFilesPath}/assimilatorStuck.txt
 	    echo "" | mail -s 'assimilator stuck' sixtadm@cern.ch
 	else
 	    echo "assimilator still stuck at `date +%Y-%m-%d\ %H:%M:%S`"
@@ -32,14 +32,15 @@ if [ -e ${lastMtimeFile} ] ; then
 	if [ ${lastUpdate} -eq 1 ] ; then
 	    # assimilator log restarted
 	    echo "assimilator restarted: ${presTime}"
-	    echo "${presTime}" >> ${logFilesPath}/assimilatorRestart.txt
+	    echo "${presTime}" | tee -a ${logFilesPath}/assimilatorRestart.txt
 	else
 	    echo "assimilator running regularly"
 	fi
     fi
 fi
 
-echo "${presTime}" > ${lastMtimeFile}
-echo "${presUpdate}" >> ${lastMtimeFile}
+echo "saving status in ${lastMtimeFile} ..."
+echo "${presTime}" | tee ${lastMtimeFile}
+echo "${presUpdate}" | tee -a ${lastMtimeFile}
 
 echo " ...done."

--- a/boinc_software/monitor-boinc-server/general-activity/parseStudyStates.py
+++ b/boinc_software/monitor-boinc-server/general-activity/parseStudyStates.py
@@ -50,15 +50,15 @@ if ( __name__ == "__main__" ):
             oFile.write("# status at %s\n"%(now))
             strOut="# %-58s,"%("study name")
             if (lPrintAssimilateState): strOut+=", ".join( "assimilate_state=%1s"%(key) for key in sorted(allStates) )+", "
-            strOut+="%18s, % 12s, % 12s" %("total","progress [%]", "missing [%]")
+            strOut+="%18s, %14s, %14s" %("total","assimilated [%]", "missing [%]")
             oFile.write('%s\n'%(strOut))
             for studyName in sorted(studiesStates.keys()):
                 strOut="%-60s"%(studyName)
                 if (lPrintAssimilateState): strOut+=" ".join( ( "%19i"%(studiesStates[studyName]['assimilate_state'][key]) for key in sorted(allStates) ) )
                 tot=sum(studiesStates[studyName]['assimilate_state'].values())
-                strOut+=" %19i"%(tot)
-                strOut+=" %- 14.3f"%(studiesStates[studyName]['assimilate_state']['2']*100.0/tot)
-                strOut+=" %- 14.3f"%((1-studiesStates[studyName]['assimilate_state']['2']*1.0/tot)*100)
+                strOut+=" %18i"%(tot)
+                strOut+=" % 16.3f"%(studiesStates[studyName]['assimilate_state']['2']*100.0/tot)
+                strOut+=" % 15.3f"%((1-studiesStates[studyName]['assimilate_state']['2']*1.0/tot)*100)
                 oFile.write('%s\n'%(strOut))
     
     exit(0)

--- a/boinc_software/monitor-boinc-server/general-activity/parseStudyStates.py
+++ b/boinc_software/monitor-boinc-server/general-activity/parseStudyStates.py
@@ -50,7 +50,7 @@ if ( __name__ == "__main__" ):
             oFile.write("# status at %s\n"%(now))
             strOut="# %-58s,"%("study name")
             if (lPrintAssimilateState): strOut+=", ".join( "assimilate_state=%1s"%(key) for key in sorted(allStates) )+", "
-            strOut+="%18s, %14s, %14s" %("total","assimilated [%]", "missing [%]")
+            strOut+="%18s, %14s, %18s" %("total","assimilated [%]", "prog./queue [%]")
             oFile.write('%s\n'%(strOut))
             for studyName in sorted(studiesStates.keys()):
                 strOut="%-60s"%(studyName)
@@ -58,7 +58,7 @@ if ( __name__ == "__main__" ):
                 tot=sum(studiesStates[studyName]['assimilate_state'].values())
                 strOut+=" %18i"%(tot)
                 strOut+=" % 16.3f"%(studiesStates[studyName]['assimilate_state']['2']*100.0/tot)
-                strOut+=" % 15.3f"%((1-studiesStates[studyName]['assimilate_state']['2']*1.0/tot)*100)
+                strOut+=" % 19.3f"%((1-studiesStates[studyName]['assimilate_state']['2']*1.0/tot)*100)
                 oFile.write('%s\n'%(strOut))
     
     exit(0)

--- a/boinc_software/monitor-boinc-server/general-activity/parseStudyStates.py
+++ b/boinc_software/monitor-boinc-server/general-activity/parseStudyStates.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+
+if ( __name__ == "__main__" ):
+
+    iFileName="all_WUs.txt"
+    oFileName="studies.txt"
+    lPrintAssimilateState=False
+
+    print "parsing %s file..."%(iFileName)
+    studiesStates={}
+    headers=None
+    with open(iFileName,'r') as iFile:
+        for line in iFile.readlines():
+            if ( "name" in line and "assimilate_state" in line):
+                headers=line.split()
+                continue
+            elif ( line.startswith("now:") ):
+                now=line[len("now:"):].strip()
+                continue
+            if (headers is None):
+                print "no header found or name and assimilate_state columns not in header"
+                exit(1)
+            for datum,fieldName in zip(line.split(),headers):
+                if (fieldName=="name"):
+                    studyName=datum.split("__")[0]
+                    if (not studiesStates.has_key(studyName)):
+                        studiesStates[studyName]={}
+                        studiesStates[studyName]['assimilate_state']={}
+                elif(fieldName=="assimilate_state"):
+                    assimilate_state=int(float(datum))
+                    if (not studiesStates[studyName]['assimilate_state'].has_key(datum)):
+                        studiesStates[studyName]['assimilate_state'][datum]=0
+            studiesStates[studyName]['assimilate_state']['%1i'%(assimilate_state)]+=1
+        print " ...done."
+    
+    if (len(studiesStates)==0):
+        print "no WU acquired - something wrong"
+        exit(1)
+    else:
+        allStates=[]
+        for studyName in sorted(studiesStates.keys()):
+            allStates+=studiesStates[studyName]['assimilate_state'].keys()
+        allStates=list(set(allStates))
+        for studyName in sorted(studiesStates.keys()):
+            for tmpState in allStates:
+                if ( not studiesStates[studyName]['assimilate_state'].has_key(tmpState) ):
+                    studiesStates[studyName]['assimilate_state'][tmpState]=0
+        with open(oFileName,'w') as oFile:
+            oFile.write("# found %i studies\n"%(len(studiesStates)))
+            oFile.write("# status at %s\n"%(now))
+            strOut="# %-58s,"%("study name")
+            if (lPrintAssimilateState): strOut+=", ".join( "assimilate_state=%1s"%(key) for key in sorted(allStates) )+", "
+            strOut+="%18s, % 12s, % 12s" %("total","progress [%]", "missing [%]")
+            oFile.write('%s\n'%(strOut))
+            for studyName in sorted(studiesStates.keys()):
+                strOut="%-60s"%(studyName)
+                if (lPrintAssimilateState): strOut+=" ".join( ( "%19i"%(studiesStates[studyName]['assimilate_state'][key]) for key in sorted(allStates) ) )
+                tot=sum(studiesStates[studyName]['assimilate_state'].values())
+                strOut+=" %19i"%(tot)
+                strOut+=" %- 14.3f"%(studiesStates[studyName]['assimilate_state']['2']*100.0/tot)
+                strOut+=" %- 14.3f"%((1-studiesStates[studyName]['assimilate_state']['2']*1.0/tot)*100)
+                oFile.write('%s\n'%(strOut))
+    
+    exit(0)
+    
+

--- a/boinc_software/monitor-boinc-server/general-activity/queryStudies.sh
+++ b/boinc_software/monitor-boinc-server/general-activity/queryStudies.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+lQuery=true
+lPython=true
+
+oFile=all_WUs.txt
+passWd=`cat ~/private/.mySQLcred`
+
+now=`date '+%F %T'`
+
+echo ""
+echo "starting at ${now} ..."
+
+if ${lQuery} ; then
+    echo "   querying the database ..."
+    echo "now: ${now}"> ${oFile}
+    mysql -h dbod-sixtrack.cern.ch -u sixtadm --password="${passWd}" -P 5513 -Dsixt_production -e"select name,assimilate_state from workunit where appid=1 or appid=10;"  >> ${oFile}
+    echo "   ...done."
+fi
+
+if ${lPython} ; then
+    echo "   parsing results..."
+    python parseStudyStates.py
+    if [ $? -eq 0 ] ; then
+	rm all_WUs.txt
+    fi
+    echo "   ...done."
+fi
+
+echo "...done."

--- a/boinc_software/monitor-boinc-server/submissions/archive/plotData_period.gnu
+++ b/boinc_software/monitor-boinc-server/submissions/archive/plotData_period.gnu
@@ -20,9 +20,9 @@ tStep=1*3600
 # time interval
 # AM -> tMin='2017-05-23T00:00:00'
 # AM -> tMin='2017-06-15T00:00:00'
-tMin='2019-04-29T00:00:00'
-tMax='2019-05-20T23:59:59'
-tStep=3600*12
+tMin='2019-05-01T00:00:00'
+tMax='2019-07-01T00:00:00'
+tStep=3600*24
 
 # typical enlarged window size: 1900,400
 # trigger use of png or interactive windows: 0: png, 1: interactive
@@ -30,7 +30,7 @@ linteractive=0
 lprintDate=0 # 0: no date/time in png name; 1: date/time in png name
 xSizeWdw=1600#regular: 1000
 ySizeWdw=600#regular: 400
-lLog=0 # 1: log y-axis; 0: linear y-axis
+lLog=1 # 1: log y-axis; 0: linear y-axis
 
 if ( lprintDate==0 ) {
 rightNowPNG=''
@@ -52,9 +52,9 @@ system( "awk '{if ($1!=\"#\") {print ($6,$4)}}' ".iFileName." | sort -k 1 | awk 
 
 set xdata time
 set timefmt '%Y-%m-%dT%H:%M:%S'
-set format x '%Y-%m-%d %H:%M'
-# set format x '%Y-%m-%d'
-set xtics rotate by 90 tStep left
+# set format x '%Y-%m-%d %H:%M'
+set format x '%Y-%m-%d'
+set xtics rotate by 90 tStep right
 tMin=strptime("%Y-%m-%dT%H:%M:%S",tMin)
 tMax=strptime("%Y-%m-%dT%H:%M:%S",tMax)
 set xrange [tMin:tMax]
@@ -68,38 +68,42 @@ set output '/afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/m
 } else {
 set term qt 10 title currTitle size xSizeWdw,ySizeWdw
 }
-set ylabel 'submitted WUs [10^6]'
 if ( lLog==1 ) {
+set ylabel 'submitted WUs []'
+scaleFact=1E0
 set logscale y
 set grid xtics ytics mxtics mytics
 set grid layerdefault   linetype -1 linecolor rgb "gray"  linewidth 0.200,  linetype 0 linecolor rgb "gray"  linewidth 0.200
 set format y '10^{%L}'
 set mytics 10
+} else {
+set ylabel 'submitted WUs [10^6]'
+scaleFact=1E6
 }
 
 plot \
-     "< awk '{if ($6==\"mcrouch\") {tot+=$4; print ($1,$3,tot)}}'  ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'black'          title 'mcrouch',\
-     "< awk '{if ($6==\"ynosochk\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'dark-green'     title 'ynosochk',\
-     "< awk '{if ($6==\"emaclean\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'green'          title 'emaclean',\
-     "< awk '{if ($6==\"fvanderv\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'blue'           title 'fvanderv',\
-     "< awk '{if ($6==\"kaltchev\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'magenta'        title 'kaltchev',\
-     "< awk '{if ($6==\"phermes\") {tot+=$4; print ($1,$3,tot)}}'  ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'cyan'           title 'phermes',\
-     "< awk '{if ($6==\"nkarast\") {tot+=$4; print ($1,$3,tot)}}'  ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'orange'         title 'nkarast',\
-     "< awk '{if ($6==\"dpellegr\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'pink'           title 'dpellegr',\
-     "< awk '{if ($6==\"ecruzala\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'navy'           title 'ecruzala',\
-     "< awk '{if ($6==\"amereghe\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'purple'         title 'amereghe',\
-     "< awk '{if ($6==\"rdemaria\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'yellow'         title 'rdemaria',\
-     "< awk '{if ($6==\"jbarranc\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'dark-blue'      title 'jbarranc',\
-     "< awk '{if ($6==\"giovanno\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'gold'           title 'giovanno',\
-     "< awk '{if ($6==\"mcintosh\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'violet'         title 'mcintosh',\
-     "< awk '{if ($6==\"skostogl\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'dark-red'       title 'skostogl',\
-     "< awk '{if ($6==\"lcoyle\") {tot+=$4; print ($1,$3,tot)}}'   ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'salmon'         title 'lcoyle',\
-     "< awk '{if ($6==\"mihofer\") {tot+=$4; print ($1,$3,tot)}}'  ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'olive'          title 'mihofer',\
-     "< awk '{if ($6==\"xiaohan\") {tot+=$4; print ($1,$3,tot)}}'  ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'skyblue'        title 'xiaohan',\
-     "< awk '{if ($6==\"dmirarch\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'slategray'      title 'dmirarch',\
-     "< awk '{if ($6==\"dalena\") {tot+=$4; print ($1,$3,tot)}}'   ".iFileName index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'dark-plum'      title 'dalena',\
-     "< awk '{if ($6==\"mischenk\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/1E3) with steps lt 1 lw 3 lc rgb 'dark-goldenrod' title 'mischenk',\
-     "< awk '{if ($6==\"-\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName        index 0 using 1:($3/1E6) with steps lt 1 lw 3 lc rgb 'red'            title '-'
+     "< awk '{if ($6==\"mcrouch\") {tot+=$4; print ($1,$3,tot)}}'  ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'black'          title 'mcrouch',\
+     "< awk '{if ($6==\"ynosochk\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'dark-green'     title 'ynosochk',\
+     "< awk '{if ($6==\"emaclean\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'green'          title 'emaclean',\
+     "< awk '{if ($6==\"fvanderv\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'blue'           title 'fvanderv',\
+     "< awk '{if ($6==\"kaltchev\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'magenta'        title 'kaltchev',\
+     "< awk '{if ($6==\"phermes\") {tot+=$4; print ($1,$3,tot)}}'  ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'cyan'           title 'phermes',\
+     "< awk '{if ($6==\"nkarast\") {tot+=$4; print ($1,$3,tot)}}'  ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'orange'         title 'nkarast',\
+     "< awk '{if ($6==\"dpellegr\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'pink'           title 'dpellegr',\
+     "< awk '{if ($6==\"ecruzala\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'navy'           title 'ecruzala',\
+     "< awk '{if ($6==\"amereghe\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'purple'         title 'amereghe',\
+     "< awk '{if ($6==\"rdemaria\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'yellow'         title 'rdemaria',\
+     "< awk '{if ($6==\"jbarranc\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'dark-blue'      title 'jbarranc',\
+     "< awk '{if ($6==\"giovanno\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'gold'           title 'giovanno',\
+     "< awk '{if ($6==\"mcintosh\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'violet'         title 'mcintosh',\
+     "< awk '{if ($6==\"skostogl\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'dark-red'       title 'skostogl',\
+     "< awk '{if ($6==\"lcoyle\") {tot+=$4; print ($1,$3,tot)}}'   ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'salmon'         title 'lcoyle',\
+     "< awk '{if ($6==\"mihofer\") {tot+=$4; print ($1,$3,tot)}}'  ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'olive'          title 'mihofer',\
+     "< awk '{if ($6==\"xiaohan\") {tot+=$4; print ($1,$3,tot)}}'  ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'skyblue'        title 'xiaohan',\
+     "< awk '{if ($6==\"dmirarch\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'slategray'      title 'dmirarch',\
+     "< awk '{if ($6==\"dalena\") {tot+=$4; print ($1,$3,tot)}}'   ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'dark-plum'      title 'dalena',\
+     "< awk '{if ($6==\"mischenk\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'dark-goldenrod' title 'mischenk',\
+     "< awk '{if ($6==\"-\") {tot+=$4; print ($1,$3,tot)}}' ".iFileName        index 0 using 1:($3/scaleFact) with steps lt 1 lw 3 lc rgb 'red'            title '-'
 #
 if (lLog==1){
 unset logscale y

--- a/boinc_software/monitor-boinc-server/submissions/plotData.gnu
+++ b/boinc_software/monitor-boinc-server/submissions/plotData.gnu
@@ -1,5 +1,5 @@
 # today=system("date +%F")
-today='2019-06-13'
+today='2019-06-17'
 iFileName='submitAll_'.today.'.dat'
 iFileNameAssimilated='assimilateAll_'.today.'.dat'
 oFileName='submitAll_'.today.'.ps'

--- a/boinc_software/monitor-boinc-server/submissions/plotData.gnu
+++ b/boinc_software/monitor-boinc-server/submissions/plotData.gnu
@@ -1,5 +1,5 @@
 # today=system("date +%F")
-today='2019-05-28'
+today='2019-06-13'
 iFileName='submitAll_'.today.'.dat'
 iFileNameAssimilated='assimilateAll_'.today.'.dat'
 oFileName='submitAll_'.today.'.ps'

--- a/boinc_software/monitor-boinc-server/submissions/retrieveData.sh
+++ b/boinc_software/monitor-boinc-server/submissions/retrieveData.sh
@@ -23,7 +23,7 @@ echo " starting `basename $0` at `date` ..."
 if ${lretrieve} ; then
     echo " retrieving submitted WUs and time intervals from log files on ${boincServer} - date: ${tmpDate}"
     # do not use grep -h: the script still needs the study name (from the submit.*.log file)!
-    ssh sixtadm@${boincServer} "cd ${sixtrackProjPath}/log_boincai11 ; grep -e $tmpDate submit*log | awk '{sub(/:/,\"\ \",\$0); print (\$0)}' | sort -k2 > ${where}/submitAll_${tmpDate}.txt"
+    ssh sixtadm@${boincServer} "cd ${sixtrackProjPath}/log_boincai11 ; grep -e $tmpDate submit*log | grep Submitted | awk '{sub(/:/,\"\ \",\$0); print (\$0)}' | sort -k2 > ${where}/submitAll_${tmpDate}.txt"
     echo " reshuffling retrieve info in a more compact and plottable way in submitAll_${tmpDate}.dat ..."
     # $1 is really the study name (from the submit.*.log file)
     # awk '{if ($1!=lastStudy) {print (tStart,lastLine,Ntot); tStart=$2; Ntot=0;} Ntot=Ntot+1; lastLine=$0; lastStudy=$1;}END{print (tStart,$0,Ntot)}' submitAll_${tmpDate}.txt > submitAll_${tmpDate}.dat


### PR DESCRIPTION
This PR is aimed at updating the monitoring scripts with few modifications:
   * added a script for getting status of WUs on BOINC from BOINC DB; the script generates a table, listing all study names, total number of WUs present in DB (affected by purge!), the fraction being assimilated and the fraction still in the queue / being crunched. The `README.md` describing the monitoring scripts has been updated accordingly;
   * bug fix in `retrieveData.sh`, grepping actually submitted WUs and not all; otherwise, errors in submitted WUs were counted as actual submissions by an unidentified user;
   * plotted range of TFLOPs between 70 and 145 (previously it was between 0 and 125);
   * lighter calls in `monitorAssimilatorTimeStamp.sh` and better logging;
   * usual update of dates in plotting scripts for monitoring BOINC status / submitted WUs;