### PR TITLE
Updates in monitoring scripts

### DIFF
--- a/boinc_software/cronjobs/acrontab_jobs_sixtadm.txt
+++ b/boinc_software/cronjobs/acrontab_jobs_sixtadm.txt
@@ -17,20 +17,20 @@
 0 3 * * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/download ; ./clean.sh >> clean.log 2>&1
 #
 # actually delete old studies
-20 3 * * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinc ; /afs/cern.ch/user/s/sixtadm/boinc_soft/deleteStudies.sh >> /afs/cern.ch/user/s/sixtadm/boinc_soft/deleteStudies.log 2>&1
-40 3 * * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinctest ; /afs/cern.ch/user/s/sixtadm/boinc_soft/deleteStudies.sh >> /afs/cern.ch/user/s/sixtadm/boinc_soft/deleteStudies.log 2>&1
+20 3 * * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinc ; /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/deleteStudies.sh >> /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/deleteStudies.log 2>&1
+40 3 * * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinctest ; /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/deleteStudies.sh >> /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/deleteStudies.log 2>&1
 #
 # list studies in spooldirs that could be deleted and notify users (based on <workspace>_<study> dir itself):
-0 4 1 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinc ; /afs/cern.ch/user/s/sixtadm/boinc_soft/listDeleteStudies.sh >> /afs/cern.ch/user/s/sixtadm/boinc_soft/deleteStudies.log 2>&1
-0 5 1 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinctest ; /afs/cern.ch/user/s/sixtadm/boinc_soft/listDeleteStudies.sh >> /afs/cern.ch/user/s/sixtadm/boinc_soft/deleteStudies.log 2>&1
+0 4 1 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinc ; /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/listDeleteStudies.sh >> /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/deleteStudies.log 2>&1
+0 5 1 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinctest ; /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/listDeleteStudies.sh >> /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/deleteStudies.log 2>&1
 #
 # list studies in spooldirs that could be deleted and notify users (based on <workspace>_<study>/work dir):
-0 4 11 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinc ; /afs/cern.ch/user/s/sixtadm/boinc_soft/listDeleteStudies.sh work >> /afs/cern.ch/user/s/sixtadm/boinc_soft/deleteStudies.log 2>&1
-0 5 11 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinctest ; /afs/cern.ch/user/s/sixtadm/boinc_soft/listDeleteStudies.sh work >> /afs/cern.ch/user/s/sixtadm/boinc_soft/deleteStudies.log 2>&1
+0 4 11 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinc ; /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/listDeleteStudies.sh work >> /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/deleteStudies.log 2>&1
+0 5 11 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinctest ; /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/listDeleteStudies.sh work >> /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/deleteStudies.log 2>&1
 #
 # list studies in spooldirs that could be deleted and notify users (based on <workspace>_<study>/results dir):
-0 4 21 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinc ; /afs/cern.ch/user/s/sixtadm/boinc_soft/listDeleteStudies.sh results >> /afs/cern.ch/user/s/sixtadm/boinc_soft/deleteStudies.log 2>&1
-0 5 21 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinctest ; /afs/cern.ch/user/s/sixtadm/boinc_soft/listDeleteStudies.sh results >> /afs/cern.ch/user/s/sixtadm/boinc_soft/deleteStudies.log 2>&1
+0 4 21 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinc ; /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/listDeleteStudies.sh results >> /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/deleteStudies.log 2>&1
+0 5 21 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinctest ; /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/listDeleteStudies.sh results >> /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/deleteStudies.log 2>&1
 #
 #
 # new scripts for monitoring BOINC server:
@@ -43,5 +43,11 @@
 35 1,7,13,19 * * * lxplus.cern.ch cd /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/monitor-boinc-server/submissions ; ./monitorSubmissions.sh >> monitorSubmissions.log 2>&1
 15 0 * * * lxplus.cern.ch cd /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/monitor-boinc-server/submissions ; ./monitorSubmissions.sh yesterday >> monitorSubmissions.log 2>&1 ; ./monitorSubmissionsDailyArchive.sh >> monitorSubmissions.log 2>&1
 # assimilator getting stuck
-1,6,11,16,21,26,31,36,41,46,51,56 * * * * lxplus.cern.ch cd /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/monitor-boinc-server/general-activity ; ./monitorAssimilatorTimeStamp.sh >> /dev/null 2>&1
+# 1,6,11,16,21,26,31,36,41,46,51,56 * * * * lxplus.cern.ch cd /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/monitor-boinc-server/general-activity ; ./monitorAssimilatorTimeStamp.sh >> /dev/null 2>&1
+1,6,11,16,21,26,31,36,41,46,51,56 * * * * lxplus.cern.ch cd /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/monitor-boinc-server/general-activity ; ./monitorAssimilatorTimeStamp.sh >> monitorAssimilatorTimeStamp.sh.log 2>&1
 #
+# update summary plots monitoring BOINC:
+35 2,8,14,20 * * * lxplus.cern.ch cd /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/monitor-boinc-server/boincStatus ; ./updatePlots.sh >> updatePlots.log 2>&1
+#
+# query the BOINC production DB and get current status of studies
+24 * * * * lxplus.cern.ch cd /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/monitor-boinc-server/general-activity ; ./queryStudies.sh >> queryStudies.sh.log 2>&1

--- a/boinc_software/cronjobs/deleteStudies.sh
+++ b/boinc_software/cronjobs/deleteStudies.sh
@@ -16,7 +16,8 @@ if [ $? -eq 0 ] ; then
     for userfile in `ls -1 delete/*` ; do
 	echo ""
 	echo "file ${userfile} ..."
-	dos2unix ${userfile}
+	dos2unix -n ${userfile} ${userfile}_temp
+	mv ${userfile}_temp ${userfile}
 	allStudies=`grep . ${userfile} | grep -v '#' | awk '{for (ii=1;ii<=NF;ii++) {print ($ii)}}'`
 	echo "removing the following study dirs and freeing space:"
 	duLines=`\du -ch --summarize ${allStudies}`

--- a/boinc_software/cronjobs/listDeleteStudies.sh
+++ b/boinc_software/cronjobs/listDeleteStudies.sh
@@ -34,6 +34,9 @@ echo " starting `basename $0` at `date` ..."
 # prepare delete dir
 [ -d delete ] || mkdir delete
 
+# prepare /tmp/sixtadm dir
+[ -d /tmp/${LOGNAME} ] || mkdir /tmp/${LOGNAME}
+
 # convert threshold in kB
 threshOccupancyKB=`echo ${threshOccupancy} | awk '{print ($1*1024**2)}'`
 
@@ -59,7 +62,7 @@ if [ -n "$1" ] ; then
     esac
 else
     echo " find old directories based on <workspace>_<studyName> only ..."
-    allStudies=`find . -maxdepth 1 -type d -ctime +${oldN} | grep -v -e upload -e delete`
+    allStudies=`find . -maxdepth 1 ! -path . -type d -ctime +${oldN} | grep -v -e upload -e delete`
     for currCase in ${allStudies} ; do
 	treatSingleDir ${currCase}
     done

--- a/boinc_software/maintain_AFS_spooldir/showSpoolDirState.sh
+++ b/boinc_software/maintain_AFS_spooldir/showSpoolDirState.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "# study, number of waiting jobs, number of waiting jobs (subFolders), number of problematic files, disk occupancy: work,results"
+echo "# study, number of waiting jobs, number of waiting jobs (subFolders) - number of problematic files - disk occupancy: work,results"
 for tmpWorkDir in `find . -maxdepth 2 -type d -name "work"` ; do
     nFiles=`ls -1 ${tmpWorkDir}/*.desc 2> /dev/null | wc -l`
     nFilesSub=`ls -1 ${tmpWorkDir}/*/*.desc 2> /dev/null | wc -l`


### PR DESCRIPTION
* bug fixes in `deleteStudies.sh` and `listDeleteStudies.sh`:
   * for the former, cleaner `dos2unix` command;
   * for the latter, current dir is not checked;
* changing header of file created by `showSpoolDirState.sh`;
* changes to list of acrontab jobs: ￼…
   * moved directory of acrontab jobs for listing/deleting old studies to a sparse checkout folder;
   * STDOUT and STDERR of `./monitorAssimilatorTimeStamp.sh` redirected to local log;
   * added acrontab job for regularly re-plotting status of BOINC server + querying the BOINC DB for WUs being treated;