### PR TITLE
fix to boinc assimilator in handling tasks with abnormal names

### DIFF
--- a/boinc_software/cronjobs/zip-trashed-WUs.sh
+++ b/boinc_software/cronjobs/zip-trashed-WUs.sh
@@ -6,6 +6,7 @@ iNLT=400
 boincDownloadDir="/afs/cern.ch/work/b/boinc/download"
 boincSpoolDirPath="/afs/cern.ch/work/b/boinc"
 allDir=all
+abnDir=abnormal
 zipToolDir=`basename $0`
 zipToolDir=${zipToolDir//.sh}
 initDir=$PWD
@@ -203,7 +204,31 @@ if [ -n "${WUs2bZipped}" ] ; then
     done
 
 else
-    log "...only super-recent WUs in ${allDir}! - skipping..."
+    log "...only super-recent WUs or no WUs at all in ${allDir}! - skipping..."
+fi
+
+cd ${initDir}
+
+# ==============================================================================
+# treat abnormal/ dir
+# ==============================================================================
+
+cd ${abnDir}
+
+# get WUs (grep -v is redundant, but it is kept for security)
+WUs2bZipped=`find . ! -path . -mmin +5 | grep -v -e '.zip' -e .doNotRemoveMe`
+
+if [ -n "${WUs2bZipped}" ] ; then
+
+    log "... ${abnDir} - results involved:"
+    log "${WUs2bZipped}"
+
+    # actually zip and move to boincDownloadDir
+    WUnames="${WUs2bZipped}"
+    treatStudy abnormal
+
+else
+    log "...only super-recent WUs or no WUs at all in ${abnDir}! - skipping..."
 fi
 
 cd ${initDir}
@@ -212,7 +237,7 @@ cd ${initDir}
 # treat studies
 # ==============================================================================
 
-for studyName in `ls -1d * | grep -v -e "^${allDir}$" -e "^${zipToolDir}$"` ; do
+for studyName in `ls -1d * | grep -v -e "^${allDir}$" -e "^${abnDir}$" -e "^${zipToolDir}$"` ; do
     log "...study ${studyName}"
     cd ${studyName}
 

--- a/boinc_software/sixtrack-assimilator/Makefile
+++ b/boinc_software/sixtrack-assimilator/Makefile
@@ -1,6 +1,6 @@
 #!make
 
-PROJ=/share/boinc/software/boinc/boinc
+PROJ=/boincdata/boinc/software/boinc_src/boinc
 SIXT=/usr/local/boinc/project/sixtrack/sixtrack-assimilator
 
 INCL=-I$(PROJ) -I$(PROJ)/lib -I$(PROJ)/db -I$(PROJ)/sched -I/usr/include/mysql

--- a/boinc_software/sixtrack-assimilator/sixtrack_assimilator.cpp
+++ b/boinc_software/sixtrack-assimilator/sixtrack_assimilator.cpp
@@ -54,6 +54,7 @@ static char *SPOOLDEP[] = {"boinc", "boinczip", "boinctest", "boincai08", "boinc
 //static char *SPOOLDIR = "/afs/cern.ch/user/b/boinc/scratch0/boinc";
 static char *RESULTDIR = "results";
 static char *RESULTALL = "all";
+static char *RESULTABNAME = "abnormal";
 static char *RESULTDIR_6 = "results";
 //static char *RESULTDIR_6 = "results_6";
 static char *ERRORREPT = "sample_results/errors";
@@ -165,9 +166,17 @@ int assimilate_handler( WORKUNIT& wu, vector<RESULT>& /*results*/, RESULT& canon
 	strncpy(buf,wu.name,STR_SIZE);
 	buf[STR_SIZE-1] = '\0';
         char *dirnul = strstr(buf,"__");           // convention: buf contains the first part of the name = directory name
-        char *dirres = (char *) (dirnul + 2);      // convention: dirres contains the second (unique) part of the name
-        *dirnul = '\0';                            // VERY IMPORTANT SETTING to separate the directory name in the buffer
-	err = 1;                                   // to let results be written to SPOOLERR directory if AFS directory not found
+        if ( dirnul == NULL ) {  // WU name does not fulfill naming convention
+          scope_messages.printf( "[%s] WU with ill name!\n",wu.name);
+          // get ready to assimilate results in RESULTABNAME
+          if( (nstr=snprintf(dire_path,STR_SIZE,"%s/%s",SPOOLERR,RESULTABNAME)) >= STR_SIZE) return write_error(1,dire_path);
+          errno = 0;
+          err = 0; 
+        } else {
+          char *dirres = (char *) (dirnul + 2);      // convention: dirres contains the second (unique) part of the name
+          *dirnul = '\0';                            // VERY IMPORTANT SETTING to separate the directory name in the buffer
+          err = 1;                                   // to let results be written to SPOOLERR directory if AFS directory not found
+        }
  
 /* iza debug:  
 	int lenwname = strlen(buf);

--- a/boinc_software/sixtrack-validator/Makefile
+++ b/boinc_software/sixtrack-validator/Makefile
@@ -1,6 +1,6 @@
 #!make
 
-PROJ=/share/boinc/software/boinc-src/boinc
+PROJ=/boincdata/boinc/software/boinc_src/boinc
 SIXT=/usr/local/boinc/project/sixtrack/sixtrack-validator
 
 INCL=-I$(PROJ) -I$(PROJ)/lib -I$(PROJ)/db -I$(PROJ)/sched -I/usr/include/mysql


### PR DESCRIPTION
This PR is aimed at fixing in the boinc assimilator the handling of tasks with abnormal names. Actually, the treated tasks as recognised as abnormal since the is no `__` in their name.

Tasks with such names are recognised, and their result files copied in:
`/share/sixtrack/assimilation/abnormal`

The `zip-trashed-WUs.sh` will then zip those files and move the archive to:
`/afs/cern.ch/work/b/boinc/download/<today>`
as done with results from studies which no longer exist on AFS spooldir