### PR TITLE
Fix validator in flagging runtime outliers

### DIFF
--- a/boinc_software/sixtrack-validator/Makefile
+++ b/boinc_software/sixtrack-validator/Makefile
@@ -1,6 +1,7 @@
 #!make
 
-PROJ=/boincdata/boinc/software/boinc_src/boinc
+# PROJ=/boincdata/boinc/software/boinc_src/boinc
+PROJ=/afs/cern.ch/work/s/sixtadm/public/boinc
 SIXT=/usr/local/boinc/project/sixtrack/sixtrack-validator
 
 INCL=-I$(PROJ) -I$(PROJ)/lib -I$(PROJ)/db -I$(PROJ)/sched -I/usr/include/mysql


### PR DESCRIPTION
This PR aims at allowing the validator to flag both results being validated as runtime outliers if it is the case (i.e. not all particles survive). Before this PR, only the first result of the couple was flagged as runtime_outlier, since the second result was `const`.

Such a change is necessary, as very short tasks (crunched and hence validated more rapidly) can bias the FLOP estimation of the host. For instance, with the present high load of sixtrack tasks with 10^6 turns, my pc crunches them in general in 2-3 h, whereas the estimated time went down to <1h.

To allow flagging also the second result as runtime outlier, I had to remove the `const` keyword from the interface of the functions `files_match` and `compare_results`. This implies also to change in the boinc software a header file - hence the need of a local installation of the boinc software (change in `Makefile`).