### PR TITLE
EOS spooling and traffic light

### DIFF
--- a/boinc_software/cronjobs/acrontab_jobs_sixtadm.txt
+++ b/boinc_software/cronjobs/acrontab_jobs_sixtadm.txt
@@ -4,7 +4,7 @@
 # Puppet Name: worksubmit sixtrack 2
 7,17,27,37,47,57 * * * * boincai11.cern.ch /usr/local/boinc/project/sixtrack/bin/cron.submit-sixtracktest-simo3 -m 3000 > /dev/null 2>&1
 # Puppet Name: worksubmit sixtrack
-1,11,21,31,41,51 * * * * boincai11.cern.ch /usr/local/boinc/project/sixtrack/bin/cron.submit-sixtrack-simo3 -m 3000 > /dev/null 2>&1
+1 * * * * boincai11.cern.ch /usr/local/boinc/project/sixtrack/bin/cron.submit-sixtrack-simo3 -m 3000 > /dev/null 2>&1
 # zip all WUs which were not given back to user
 # crontab every 3h
 30 */3 * * * boincai11.cern.ch cd /share/sixtrack/assimilation ; /usr/local/boinc/project/sixtrack/bin/zip-trashed-WUs.sh > /dev/null 2>&1
@@ -31,6 +31,9 @@
 # list studies in spooldirs that could be deleted and notify users (based on <workspace>_<study>/results dir):
 0 4 21 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinc ; /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/listDeleteStudies.sh results >> /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/deleteStudies.log 2>&1
 0 5 21 * * lxplus.cern.ch cd /afs/cern.ch/work/b/boinc/boinctest ; /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/listDeleteStudies.sh results >> /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/deleteStudies.log 2>&1
+#
+# tar.gz new job and spool it to EOS
+4,14,24,34,44,54 * * * * lxplus.cern.ch /afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/cronjobs/mv2EOS.sh > /dev/null 2>&1
 #
 #
 # new scripts for monitoring BOINC server:

--- a/boinc_software/cronjobs/cron.submit-simo3
+++ b/boinc_software/cronjobs/cron.submit-simo3
@@ -7,6 +7,7 @@
 # Updated 06.10.2016 A.Mereghetti, added megaZip functionality
 # Updated 25.03.2017 A.Mereghetti, SixOut.zip + appname (from .desc)
 # Updated 01.05.2019 A.Mereghetti, appnum + default appNum
+# Updated 13.09.2019 A.Mereghetti, EOS spooling
 set -e
 
 #Set Variables
@@ -36,6 +37,13 @@ WU_template=templates/${applicationDef}_wu_template.xml
 # The relative path of the result template file from the config dir.
 # this template will bring back also the Sixout.zip results
 result_template_SixOutZip=templates/${applicationDef}_res_template.xml
+
+export EOS_MGM_URL=root://eosuser.cern.ch 
+pathInEos=/eos/user/s/sixtadm/spooldirs/uploads/boinc
+tmpDirBase=/tmp/sixtadm/`basename $0`/boinc
+nMaxRetrial=10
+
+TLpath="/afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/monitor-boinc-server/general-activity/SixTrack_status_????-??-??.dat"
 
 #Define finctions
 abort(){
@@ -112,7 +120,8 @@ run_spool_megazip(){
 
     megaZip=1
     
-    find "$spooldirUpload" -mmin +5 -name "*.zip" | (
+    # take into account arrival time
+    find "$spooldirUpload" -mmin +5 -name "*.zip" -printf "%T+\t%p\n" | sort | awk '{print ($2)}' | (
 	while read workBatch ; do
 	    unzip -t $workBatch  >/dev/null 2>&1
 	    if [ $? -ne 0 ] ; then
@@ -123,22 +132,25 @@ run_spool_megazip(){
 	    origPath=`mktemp -d -p /tmp/`
 	    warn "$workBatch being processed in $origPath ..."
 	    cp $workBatch $origPath
-	    # remember that you must run in $boincdir
-	    unzip $workBatch -d $origPath >/dev/null 2>&1
-	    # check for unzipped .desc files
-	    find $origPath -maxdepth 1 -type f -name '*.desc' | (
-	        while read descfile ; do
-		    # process the desc files
-		    if submit_descfile "$descfile" ; then
-			logstudy "Submitted $WUname"
-		    else
-			logstudy "Problem submitting $WUname"
-		    fi
-	        done
-	    )
-	    warn " ...going on with next MegaZip."
-	    rm -rf $origPath
-	    rm $workBatch
+	    nForeseen=`unzip -l ${workBatch} | wc -l`
+	    if traffic_light ; then
+	        # remember that you must run in $boincdir
+	        unzip $workBatch -d $origPath >/dev/null 2>&1
+	        # check for unzipped .desc files
+	        find $origPath -maxdepth 1 -type f -name '*.desc' | (
+	            while read descfile ; do
+	        	    # process the desc files
+	        	    if submit_descfile "$descfile" ; then
+	        		logstudy "Submitted $WUname"
+	        	    else
+	        		logstudy "Problem submitting $WUname"
+	        	    fi
+	            done
+	        )
+	        warn " ...going on with next MegaZip."
+	        rm -rf $origPath
+	        rm $workBatch
+	    fi
 	done
     )
 }
@@ -158,7 +170,8 @@ run_spool(){ # max_jobs_to_submit, max_jobs_perStudy, specific_study
 
     if [ -z "$3" ] ; then
         #find the work dirs 2 levels down
-	local allWorkDirs=`find "$spooldir" -maxdepth 2 -type d -name "work"`
+	# take into account arrival time
+	local allWorkDirs=`find "$spooldir" -maxdepth 2 -type d -name "work" -printf "%T+\t%p\n" | sort | awk '{print ($2)}'`
     else
 	#target a specific study
 	local allWorkDirs=$spooldir/$3/work
@@ -168,37 +181,170 @@ run_spool(){ # max_jobs_to_submit, max_jobs_perStudy, specific_study
     for workdir in ${allWorkDirs} ; do
         ! ${lMaxJobsPerStudy} || local __StudyComplete=0
 	#check for desc files in the current work dir, and subfolders
+	# take into account arrival time
 	if ${lMaxJobsPerStudy} ; then
-	    local allDescs=`find "$workdir" -maxdepth 2 -type f -name '*.desc' | head -n ${max_jobs_perStudy}`
+	    local allDescs=`find "$workdir" -maxdepth 2 -type f -name '*.desc' -printf "%T+\t%p\n" | sort | awk '{print ($2)}' | head -n ${max_jobs_perStudy}`
 	else
-	    local allDescs=`find "$workdir" -maxdepth 2 -type f -name '*.desc'`
+	    local allDescs=`find "$workdir" -maxdepth 2 -type f -name '*.desc' -printf "%T+\t%p\n" | sort | awk '{print ($2)}'`
 	fi
-	for descfile in ${allDescs} ; do
-	    #process the desc files
-	    origPath=`dirname ${descfile}`
-            ! ${lMaxJobsPerStudy} || let __StudyComplete+=1
-	    if submit_descfile "$descfile" ; then
-		logstudy "Submitted $WUname"
-		#stop after max_jobs (0=unlimited)
-		if ${lMaxJobs} ; then
-		    complete=$(( $complete + 1 ))
-		    if [ $complete -ge $max_jobs ] ; then
-                        log "reached ${max_jobs} in total"
-			break 2
-		    fi
-		fi
-	    else
-		logstudy "Problem submitting $WUname"
-	    fi
-	done
-	if [ -n "${allDescs}" ] ; then
-	    if ${lMaxJobsPerStudy} ; then
-                if [ ${__StudyComplete} -eq ${max_jobs_perStudy} ] ; then
-		    log "limit to ${max_jobs_perStudy} reached for ${workdir}"
+	nForeseen=`echo "${allDescs}" | wc -l`
+	let nForeseen=${nForeseen}*2
+	if traffic_light ; then
+	    for descfile in ${allDescs} ; do
+	        #process the desc files
+	        origPath=`dirname ${descfile}`
+                ! ${lMaxJobsPerStudy} || let __StudyComplete+=1
+	        if submit_descfile "$descfile" ; then
+	    	logstudy "Submitted $WUname"
+	    	#stop after max_jobs (0=unlimited)
+	    	if ${lMaxJobs} ; then
+	    	    complete=$(( $complete + 1 ))
+	    	    if [ $complete -ge $max_jobs ] ; then
+                            log "reached ${max_jobs} in total"
+	    		break 2
+	    	    fi
+	    	fi
+	        else
+	    	logstudy "Problem submitting $WUname"
 	        fi
-            fi
+	    done
+	    if [ -n "${allDescs}" ] ; then
+	        if ${lMaxJobsPerStudy} ; then
+                    if [ ${__StudyComplete} -eq ${max_jobs_perStudy} ] ; then
+	    	    log "limit to ${max_jobs_perStudy} reached for ${workdir}"
+	            fi
+                fi
+	    fi
 	fi
     done
+}
+
+run_spool_EOS(){
+
+    # get .tar.gz files from ${pathInEos} (path in EOS) and 
+    #     ${spooldirUpload} (back-up in AFS in case of problems with EOS)
+
+    megaZip=0
+    origPath=${tmpDirBase}
+
+    for __tmpSourceDir in ${pathInEos} ${spooldirUpload} ; do
+
+	if [[ "${__tmpSourceDir}" == "/eos"* ]] ; then
+	    gzFiles=`eos find -name "*.tar.gz" ${__tmpSourceDir}`
+	else
+	    gzFiles=`find ${__tmpSourceDir} -mmin +5 -name "*.tar.gz"`
+	fi
+	
+	log ".tar.gz files in ${__tmpSourceDir}:"
+	echo "${gzFiles}" | log
+	
+        for gzFile in ${gzFiles} ; do
+        
+            gzFileName=`basename ${gzFile}`
+
+	    if [[ "${__tmpSourceDir}" == "/eos"* ]] ; then
+		myCommand="xrdcp --cksum adler32 ${EOS_MGM_URL}/${pathInEos}/${gzFileName} ${tmpDirBase}"
+		loopMe
+		if [ $? -ne 0 ] ; then
+        	    log "unable to download ${gzFileName} from EOS ${EOS_MGM_URL}/${pathInEos}"
+        	    continue
+		fi
+	    else
+		myCommand="cp ${gzFile} ${tmpDirBase}"
+		loopMe
+		if [ $? -ne 0 ] ; then
+		    log "unable to download ${gzFileName} from AFS ${spooldirUpload}"
+		    continue
+		fi
+	    fi
+
+	    spool_EOS_gunzip || continue
+		
+	    tarFile=${tmpDirBase}/${gzFileName%.gz}
+	    spool_EOS_untar || continue
+	    
+	    spool_EOS_descfiles
+		
+	    # clean
+	    if [[ "${__tmpSourceDir}" == "/eos"* ]] ; then
+		eos rm ${pathInEos}/${gzFileName}
+	    else
+		rm ${gzFile}
+	    fi
+	    rm ${tarFile}
+        done
+
+    done
+}
+
+function spool_EOS_gunzip(){
+    myCommand="gunzip ${tmpDirBase}/${gzFileName}"
+    if loopMe ; then
+	return 0
+    else
+        log "unable to gunzip ${gzFileName}"
+	rm ${tmpDirBase}/${gzFileName}
+        return 1
+    fi
+}
+
+function spool_EOS_untar(){
+    nForeseen=`tar -tvf ${tarFile} | wc -l`
+    # tar -tvf always returns a '.'
+    nForeseen=$(( $nForeseen -1 ))
+    if traffic_light ; then
+	myCommand="tar -xvf ${tarFile} -C ${tmpDirBase}"
+	loopMe
+	if [ $? -ne 0 ] ; then
+            log "unable to untar ${tarFile}"
+	    rm ${tarFile}
+            return 1
+	fi
+    else
+	rm ${tarFile}
+        return 2
+    fi
+    return 0
+}
+
+spool_EOS_descfiles(){
+    # remember that you must run in $boincdir
+    for descfile in `find "${tmpDirBase}" -type f -name '*.desc'` ; do
+        #process the desc files
+        if submit_descfile "$descfile" ; then
+            logstudy "Submitted $WUname"
+        else
+            logstudy "Problem submitting $WUname"
+        fi
+    done
+}
+
+function traffic_light(){
+    # nPresent: how many tasks presently in queue
+    # nTreated: how many tasks (factor 2 only wrt WUs) will be submitted now
+    # 0: green
+    # 1: red
+    local __nPresentTemp=`tail -1 ${TLpath} 2> /dev/null | awk '{print ($3)}'`
+    if [ -z "${__nPresentTemp}" ] ; then
+	if [ -z "${nPresent}" ] ; then
+	    log "unable to get number of queued ${applicationDef} tasks from ${TLpath}"
+	    return 2
+	else
+	    log "unable to get number of queued ${applicationDef} tasks from ${TLpath} - going on with ${nPresent}"
+	fi
+    else
+	nPresent=${__nPresentTemp}
+    fi
+    local __nTemp=$(( ${nTreated} +${nPresent} +${nForeseen} ))
+    if [ ${__nTemp} -ge ${currentLimit} ] ; then
+	log "traffic light is red (treated+present+foreseen>limit): ${nTreated}+${nPresent}+${nForeseen}>${currentLimit}"
+	nResidual=0
+	return 1
+    else
+	log "traffic light is green (treated+present+foreseen>limit): ${nTreated}+${nPresent}+${nForeseen}<${currentLimit}"
+	let nResidual=${currentLimit}+${__nTemp}
+	return 0
+    fi
 }
 
 submit_descfile(){ 
@@ -309,6 +455,7 @@ create_cmd="$boincdir/bin/create_work 		   \
 	fi
         # in case of megazip, zipfile will be deleted since the
 	#  tmp dir will be deleted
+	nTreated=$(( $nTreated +2 ))
 
 	return 0
 }
@@ -406,6 +553,22 @@ clearWUvars(){
 	unset WUapplication
 }
 
+function loopMe(){
+    # myCommand should be defined before the call
+    local __reply=1
+    local __iTrials=0
+    while [ ${__reply} -ne 0 ] && [ ${__iTrials} -lt ${nMaxRetrial} ] ; do
+        let __iTrials+=1
+        log "command: ${myCommand} - run at `date` - trial ${__iTrials}"
+        ${myCommand}
+        __reply=$?
+    done
+    if [ ${__reply} -ne 0 ] ; then
+        log " ...giving up on command."
+    fi
+    return ${__reply}
+}
+
 printhelp(){
 cat <<EOF
 Usage: $(basename $0) [options]
@@ -457,14 +620,58 @@ cd $boincdir
 getlock
 #Klog
 
+megaZip=0
+nResidual=0
+
 # preliminary: remove temp dirs in work older than 1d
-log find ${spooldir} -mindepth 3 -maxdepth 3 -mtime +1 -type d -empty -delete -print
-find ${spooldir} -mindepth 3 -maxdepth 3 -mtime +1 -type d -empty -delete -print | log
+# log find ${spooldir} -mindepth 3 -maxdepth 3 -mtime +1 -type d -empty -delete -print
+# find ${spooldir} -mindepth 3 -maxdepth 3 -mtime +1 -type d -empty -delete -print | log
 
-log run_spool $maxjobs $maxjobs_perStudy $studyName
-run_spool $maxjobs $maxjobs_perStudy $studyName
+# traffic light
+currentLimit=`grep -v '#' ${boincdir}/queue_thresholds.txt | awk -v "appName=${applicationDef}" '{if ($1==appName) {print ($2)}}' | tail -1`
+if [ -z "${currentLimit}" ] ; then
+    abort 1 "unable to get threshold of queued ${applicationDef} tasks from ${boincdir}/queue_thresholds.txt"
+fi
+nTreated=0
+nForeseen=0
+traffic_light || abort 1 "traffic light: red"
 
-log run_spool_megazip
-run_spool_megazip
+if ! [ -d ${tmpDirBase} ] ; then
+    mkdir -p ${tmpDirBase}
+    if [ $? -ne 0 ] ; then
+	abort 1 "problems in creating ${tmpDirBase} - cannot proceed"
+    fi
+fi
+origPath=${tmpDirBase}
+log "remaining .tar.gz files in ${tmpDirBase} from previous run"
+for gzFile in `find ${tmpDirBase} -name "*.tar.gz"` ; do
+    gzFileName=`basename ${gzFile}`
+    spool_EOS_gunzip || continue
+    tarFile=${tmpDirBase}/${gzFileName%.gz}
+    spool_EOS_untar || continue
+    spool_EOS_descfiles
+    rm ${tarFile}
+done
+log "remaining .tar files in ${tmpDirBase} from previous run"
+for tarFile in `find ${tmpDirBase} -name "*.tar"` ; do
+    spool_EOS_untar || continue
+    spool_EOS_descfiles
+    rm ${tarFile}
+done
+log "remaining .desc files in ${tmpDirBase} from previous run"
+spool_EOS_descfiles
+
+log run_spool_EOS
+run_spool_EOS
+
+if [ ${nResidual} -gt 0 ] && [ ${maxjobs} -gt ${nResidual} ] ; then
+    log "updating maxjobs from ${maxjobs} to ${nResidual} following limit on max number or queued tasks at ${currentLimit}"
+    maxjobs=${nResidual}
+fi
+# log run_spool $maxjobs $maxjobs_perStudy $studyName
+# run_spool $maxjobs $maxjobs_perStudy $studyName
+
+# log run_spool_megazip
+# run_spool_megazip
 
 log FINISHING

--- a/boinc_software/cronjobs/mv2EOS.sh
+++ b/boinc_software/cronjobs/mv2EOS.sh
@@ -1,60 +1,240 @@
 #!/bin/bash
 
 # A.Mereghetti, 2019-09-10
-# script for zipping WUs according to study name
-iNLT=400
-boincDownloadDir="/afs/cern.ch/work/b/boinc/download"
-boincSpoolDirPath="/afs/cern.ch/work/b/boinc"
-allDir=all
-zipToolDir=`basename $0`
-zipToolDir=${zipToolDir//.sh}
-initDir=$PWD
-tmpDirBase=/tmp/sixtadm/`basename $0`
-lTest=false
+# script for spooling tasks from AFS work.boinc volume to
+#   sixtadm EOS space
 
-boincdir=/data/boinc/project/sixtrack
+toolsDir=`dirname $0`
+tmpDirBase=/tmp/sixtadm/`basename $0`
 host=$(hostname -s)
-#
-logdir=$boincdir/log_$host
-[ -d $logdir ] || mkdir $logdir
-LOGFILE="$logdir/$(basename $0).log"
-#
-lockdir=$boincdir/pid_$host
-[ -d $lockdir ] || mkdir $lockdir
-lockfile=$lockdir/$(basename $0).lock
+
+spooldirs=( /afs/cern.ch/work/b/boinc/boinc )
+
+LOGFILE="$toolsDir/$(basename $0).log"
+lockfile="$toolsDir/$(basename $0).lock"
+
+export EOS_MGM_URL=root://eosuser.cern.ch 
+eosSpoolDirsPath=/eos/user/s/sixtadm/spooldirs
+
+nMaxRetrial=10
 
 function log(){ # log_message
-    if [ $# -gt 0 ] ; then 
-	logtofile "$*"
-    else
-	local line
-	while read line ; do 
-	        logtofile "$line"
-		done
-    fi
+    echo "$(date -Iseconds) $*" >>"$LOGFILE"
 }   
-
-function logtofile(){ #[opt-file] log_message
-    local logfile
-    logfile="$LOGFILE"
-    if [ $# -gt 1 ] ; then 
-	logfile="$logdir/$1"
-	shift
-    fi
-    echo "$(date -Iseconds) $1" >>"$logfile"
-}
 
 function getlock(){
     if  ln -s PID:$$ $lockfile >/dev/null 2>&1 ; then
-	if ${lTest} ; then
- 	    trap "rm $lockfile; log \" Relase lock $lockfile\"" EXIT
-	else
- 	    trap "log \" cleaning ${tmpDirBase} away...\" ; rm -rf ${tmpDirBase} ; rm $lockfile; log \" Relase lock $lockfile\"" EXIT
-	fi
-	log "got lock $lockfile"
+	trap "log \" cleaning ${tmpDirBase} away...\" ; rm -rf ${tmpDirBase} ; rm $lockfile; log \" Relase lock $lockfile\"" EXIT
+ 	log "got lock $lockfile"
     else 
-	log "$lockfile already exists. $PWD/$0 already running? Abort..."
+	log "$lockfile already exists. $0 already running? Abort..."
 	#never get here
 	exit 1
     fi
 }
+
+run_spool(){ # max_jobs_to_submit, max_jobs_perStudy, max_jobs_perTar, specific_study
+
+    local max_jobs="$1"	
+    local lMaxJobs=false
+    [ -z "${max_jobs}" -o "${max_jobs}" = "0" ] || lMaxJobs=true
+
+    local max_jobs_perStudy="$2"	
+    local lMaxJobsPerStudy=false
+    [ -z "${max_jobs_perStudy}" -o "${max_jobs_perStudy}" = "0" ] || lMaxJobsPerStudy=true
+
+    local max_jobs_perTar="$3"	
+    local lMaxJobsPerTar=false
+    [ -z "${max_jobs_perTar}" -o "${max_jobs_perTar}" = "0" ] || lMaxJobsPerTar=true
+
+    if [ -z "$4" ] ; then
+        #find the work dirs 2 levels down
+	# take into account arrival time
+	local allWorkDirs=`find "$spooldir" -maxdepth 2 -type d -name "work" -printf "%T+\t%p\n" | sort | awk '{print ($2)}'`
+    else
+	#target a specific study
+	local allWorkDirs=$spooldir/$4/work
+    fi
+
+    # main loop
+    local __starttime=$(date +%s)
+    local __nCompleted=0
+    for workdir in ${allWorkDirs} ; do
+        local __nCompletedStudy=0
+	#check for desc files in the current work dir, and subfolders
+	# take into account arrival time
+	if ${lMaxJobsPerStudy} ; then
+	    local allDescs=`find "$workdir" -maxdepth 2 -mmin +5 -type f -name '*.desc' -printf "%T+\t%p\n" | sort | awk '{print ($2)}' | head -n ${max_jobs_perStudy}`
+	else
+	    local allDescs=`find "$workdir" -maxdepth 2 -mmin +5 -type f -name '*.desc' -printf "%T+\t%p\n" | sort | awk '{print ($2)}'`
+	fi
+	for descfile in ${allDescs} ; do
+	    #process the desc files
+	    cp ${descfile} ${descfile%.desc}.zip ${taringDir}
+	    if [ $? -eq 0 ] ; then
+		__nCompletedStudy=$(( ${__nCompletedStudy} + 1 ))
+		__nCompleted=$(( ${__nCompleted} + 1 ))
+		log "Submitted `basename ${descfile%.desc}`"
+		rm ${descfile} ${descfile%.desc}.zip
+		# proceed with tar in case max reached
+		if ${lMaxJobsPerTar} ; then
+		    if [ $((${__nCompleted}%${max_jobs_perTar})) -eq 0 ] && [ ${__nCompleted} -ne 0 ] ; then
+                        log "reached ${max_jobs_perTar} - proceed with tar file"
+			makeTar
+		    fi
+		fi
+		# stop after max_jobs (0=unlimited)
+		if ${lMaxJobs} ; then
+		    if [ ${__nCompleted} -ge ${max_jobs} ] ; then
+                        log "reached ${max_jobs} in total"
+			break 2
+		    fi
+		fi
+	    else
+		log "Problem submitting ${descfile%.desc}"
+	    fi
+	done
+	if [ -n "${allDescs}" ] ; then
+	    if ${lMaxJobsPerStudy} ; then
+                if [ ${__nCompletedStudy} -eq ${max_jobs_perStudy} ] ; then
+		    log "limit of ${max_jobs_perStudy} reached for ${workdir}"
+	        fi
+            fi
+	fi
+    done
+
+    makeTar
+
+    local __endtime=$(date +%s)
+    local __timedelta=$((${__endtime} - ${__starttime}))
+    log "it took ${__timedelta} seconds for ${__nCompleted} WUs."
+
+}
+
+makeTar(){
+
+    local __origDir=$PWD
+    cd ${taringDir}
+
+    if [ `ls -1 *.zip 2> /dev/null | wc -l` -ne 0 ] ; then
+	tarName=`basename ${spooldir}`_`date "+%Y-%m-%d_%H-%M-%S".tar`
+	log "new tar name: ${tarName}"
+
+	myCommand="tar -cvf ../${tarName} ."
+	log "${myCommand}"
+	${myCommand}
+    else
+	log "no .zip files"
+    fi
+
+    for tarFile in `ls -1 ../*.tar 2> /dev/null` ; do
+	myCommand="gzip ${tarFile}"
+	log "${myCommand}"
+	${myCommand}
+    done
+
+    for gzFile in `ls -1 ../*.gz 2> /dev/null` ; do
+	# xrdcp tar
+	myCommand="xrdcp -f --cksum adler32 ${gzFile} ${EOS_MGM_URL}/${pathInEos}/"
+	loopMe
+	if [ $? -ne 0 ] ; then
+	    log "unable to upload to EOS at ${EOS_MGM_URL}/${pathInEos} - moving it to ${spooldirUpload}"
+	    mv ${gzFile} ${spooldirUpload}
+	fi
+    done
+
+    rm -f * ../*.gz
+    cd ${__origDir}
+}
+
+function loopMe(){
+    # myCommand should be defined before the call
+    local __reply=1
+    local __iTrials=0
+    while [ ${__reply} -ne 0 ] && [ ${__iTrials} -lt ${nMaxRetrial} ] ; do
+        let __iTrials+=1
+        log "command: ${myCommand} - run at `date` - trial ${__iTrials}"
+        ${myCommand}
+        __reply=$?
+    done
+    if [ ${__reply} -ne 0 ] ; then
+        log " ...giving up on command."
+    fi
+    return ${__reply}
+}
+
+printhelp(){
+cat <<EOF
+Usage: $(basename $0) [options]
+
+        Where options are:
+        -d string       - limit processing to the specified study only
+        -h              - print usage and exit
+        -m number       - set max no of jobs per study in the current run
+        -n number       - set max no of jobs in the current run
+        -N number       - set max no of jobs per tar in the current run
+	-k		- Keep .desc.done and .zip contents
+
+EOF
+}
+
+# ==============================================================================
+# start
+# ==============================================================================
+
+maxjobs=0 # =0: no limits
+maxjobs_perStudy=1000
+maxjobs_perTar=10000
+studyName=""
+
+while getopts ":hd:m:n:N:"  OPT
+do
+  #Debug
+  #echo "OPT is $OPT. OPTIND is $OPTIND. OPTARG is $OPTARG."
+case "$OPT" in
+h) printhelp ; exit 0 ;;
+m) maxjobs_perStudy="$OPTARG" ;;
+n) maxjobs="$OPTARG" ;;
+N) maxjobs_perTar="$OPTARG" ;;
+d) studyName="$OPTARG" ;;
+:|?) log 'Invalid Argument(s)' ; printhelp; exit 0 ;;
+esac
+done
+
+log ""
+log "starting `basename $0` at `date` on host ${host} ..."
+
+# adding lock mechanism
+getlock
+
+# ==============================================================================
+# processing
+# ==============================================================================
+
+for spooldir in ${spooldirs[@]} ; do
+    pathInEos=${eosSpoolDirsPath}/uploads/`basename ${spooldir}`
+    spooldirUpload=$spooldir/upload
+
+    taringDir=${tmpDirBase}/taring/`basename ${spooldir}`
+    if ! [ -d ${taringDir} ] ; then
+	mkdir -p ${taringDir}
+	if [ $? -ne 0 ] ; then
+	    log "problems in creating ${taringDir} - cannot proceed"
+	    exit 1
+	fi
+    fi
+
+    # finalise a potential previous round ended early
+    log "finalise a potential previous round ended early"
+    makeTar
+
+    log run_spool $maxjobs $maxjobs_perStudy $maxjobs_perTar $studyName
+    run_spool $maxjobs $maxjobs_perStudy $maxjobs_perTar $studyName
+done
+
+# ==============================================================================
+# close processing
+# ==============================================================================
+
+# done
+log "...done by `date`"

--- a/boinc_software/cronjobs/mv2EOS.sh
+++ b/boinc_software/cronjobs/mv2EOS.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# A.Mereghetti, 2019-09-10
+# script for zipping WUs according to study name
+iNLT=400
+boincDownloadDir="/afs/cern.ch/work/b/boinc/download"
+boincSpoolDirPath="/afs/cern.ch/work/b/boinc"
+allDir=all
+zipToolDir=`basename $0`
+zipToolDir=${zipToolDir//.sh}
+initDir=$PWD
+tmpDirBase=/tmp/sixtadm/`basename $0`
+lTest=false
+
+boincdir=/data/boinc/project/sixtrack
+host=$(hostname -s)
+#
+logdir=$boincdir/log_$host
+[ -d $logdir ] || mkdir $logdir
+LOGFILE="$logdir/$(basename $0).log"
+#
+lockdir=$boincdir/pid_$host
+[ -d $lockdir ] || mkdir $lockdir
+lockfile=$lockdir/$(basename $0).lock
+
+function log(){ # log_message
+    if [ $# -gt 0 ] ; then 
+	logtofile "$*"
+    else
+	local line
+	while read line ; do 
+	        logtofile "$line"
+		done
+    fi
+}   
+
+function logtofile(){ #[opt-file] log_message
+    local logfile
+    logfile="$LOGFILE"
+    if [ $# -gt 1 ] ; then 
+	logfile="$logdir/$1"
+	shift
+    fi
+    echo "$(date -Iseconds) $1" >>"$logfile"
+}
+
+function getlock(){
+    if  ln -s PID:$$ $lockfile >/dev/null 2>&1 ; then
+	if ${lTest} ; then
+ 	    trap "rm $lockfile; log \" Relase lock $lockfile\"" EXIT
+	else
+ 	    trap "log \" cleaning ${tmpDirBase} away...\" ; rm -rf ${tmpDirBase} ; rm $lockfile; log \" Relase lock $lockfile\"" EXIT
+	fi
+	log "got lock $lockfile"
+    else 
+	log "$lockfile already exists. $PWD/$0 already running? Abort..."
+	#never get here
+	exit 1
+    fi
+}


### PR DESCRIPTION
This PR aims at implementing the traffic light for BOINC submission of SixTrack tasks. At the same time, since spooling based on AFS only can become a problem due to its limited storage space, spooling to EOS has been implemented as well.

The logics is:
* users can submit tasks whenever they want; these are regularly uploaded to the boinc.work volume on AFS;
* an acrontab job on lxplus takes care of taring new tasks (input files) in zipped archives and upload the .tar.gz to EOS. Tasks are tared by order of arrival of the study, and (for a study) by order of arrival of the input files. By default, every tar contains inputs for at most 10k jobs, and 1k job per study. The acrontab job is run every 10min;
* an acrontab job on the boinc server takes care of checking the status of the queue and, in case there is room, it starts untaring the archives and submitting work to BOINC. The acrontab job does not query the DB for getting the present status of the queue, but it takes the number from the server status_page; hence, this acrontab job is run every hour. For every tar file, the job checks what is the current status of the queue, such that if the status changes, it is taken into account immediately. In addition, if there is room for new tasks, the acrontab job checks if the number of tasks in the current tar file fits into the available room; if not, the following tar is checked.

The above approach has the following assets:
* no change in user daily experience (no new scripts, errors, etc...);
* all EOS-related operations are done with native commands, e.g. xrdcp, eos find, etc... such that failures experienced earlier due to the fuse-mounted EOS will not affect the behaviour of the scripts;
* enlarged spooling space - only with the submissions from yesterday night (from 06:00 PM) to now, we would have increased the occupancy of the work.boinc volume by 20GB;
* mixing of studies, such that there are no long periods where a user/study monopolises the resources;
* both acrontab jobs have locking and logging mechanism, error handling (as much as I could without losing too much time on that), and recovery from interrupted runs;
* no additional load on the BOINC DB, as queue status is taken from the status_page;
* looping over tars when actually submitting to BOINC allows to avoid blocking processing because of big tar files.