### PR TITLE
bug fix + change default behavior of `run_six.sh`

### DIFF
--- a/utilities/bash/dot_profile
+++ b/utilities/bash/dot_profile
@@ -1281,9 +1281,11 @@ sixdeskSetQueue(){
     # . LSF: test 8nm 1nh 8nh 1nd 2nd 1nw 2nw (see http://lsf-rrd.cern.ch/lrf-lsf/)
     # . HTCONDOR: espresso (20min) microcentury (1h) longlunch (2h) workday (8h) tomorrow (1d) testmatch (3d) nextweek (1w) (see http://batchdocs.web.cern.ch/batchdocs/local/lsfmigratepractical.html)
     # verify lsf var is properly set
+    sixdeskmess 2 "queues: ${1}=${!1} - ${2}=${!2}"
     if [ -z "${!1}" ] ; then
         # assign a default value
         eval "${1}=8nh"
+        sixdeskmess 2 "LSF queue (default): ${!1}"
     else
         case ${!1} in
             8nm | 1nh | 8nh | 1nd | 2nd | 1nw | 2nw )
@@ -1296,10 +1298,11 @@ sixdeskSetQueue(){
                 ;;
         esac
     fi
+    sixdeskmess 2 "queues: ${1}=${!1} - ${2}=${!2}"
     # verify htcondor var is set:
     if [ -n "${!2}" ] ; then
         case ${!2} in
-            espresso | microcentury | workday | tomorrow | testmatch | 1nextweek )
+            espresso | microcentury | workday | tomorrow | testmatch | nextweek )
                 sixdeskmess 2 "HTCONDOR queue (sixdeskenv): ${!2}"
                 ;;
             *)
@@ -1308,6 +1311,7 @@ sixdeskSetQueue(){
                 ;;
         esac
     fi
+    sixdeskmess 2 "queues: ${1}=${!1} - ${2}=${!2}"
     if [ -z "${!2}" ] ; then
         # assign a default value based on the lsf value
         case ${!1} in


### PR DESCRIPTION
This PR aims at:
1. fixing a bug in `dot_profile` (`sixdeskSetQueue` function) in recognising `nextweek` as possible HTCondor queue. This queue was mis-typed in the list of recognised queues. Thanks to D.Mirarchi for reporting the bug;
1. changing the default behavior of `run_six.sh`. Currently, before generating inputs or checking them or submitting jobs, `run_six.sh` checks by default that the point has not been already submitted or a result is present. Previously, these three operations were done no matter the status of the folder. Thanks to F.V.D.Veken for asking for the change.

At the same time, added a couple of debugging messages in `run_six.sh` when setting the queue.