### PR TITLE
Fix traffic light

### DIFF
--- a/boinc_software/cronjobs/cron.submit-simo3
+++ b/boinc_software/cronjobs/cron.submit-simo3
@@ -42,6 +42,7 @@ export EOS_MGM_URL=root://eosuser.cern.ch
 pathInEos=/eos/user/s/sixtadm/spooldirs/uploads/boinc
 tmpDirBase=/tmp/sixtadm/`basename $0`/boinc
 nMaxRetrial=10
+reportMsg=""
 
 TLpath="/afs/cern.ch/work/s/sixtadm/public/monitor_activity/boinc_software/monitor-boinc-server/general-activity/SixTrack_status_????-??-??.dat"
 
@@ -54,6 +55,7 @@ abort(){
     fi
     error "$1"
     log "ABORT exitcode is $exitcode"
+    [ ${exitcode} -le 1 ] || echo "ERROR message: $1 - exit code: ${exitcode} - report MSG: ${reportMsg}" | mail -s "ABORT in `basename $0`" sixtadm@cern.ch
     exit $exitcode	
 }
 	
@@ -109,7 +111,7 @@ getlock(){
 	trap "rm $lockfile; log Relase lock $lockfile" EXIT
 	log Got lock $lockfile 
     else 
-	abort 1 "$lockfile already exists. $0 already running? Abort..."
+	abort 2 "$lockfile already exists. $0 already running? Abort..."
 	#never get here
 	exit 1
     fi
@@ -123,6 +125,10 @@ run_spool_megazip(){
     # take into account arrival time
     find "$spooldirUpload" -mmin +5 -name "*.zip" -printf "%T+\t%p\n" | sort | awk '{print ($2)}' | (
 	while read workBatch ; do
+
+	    nForeseen=0
+	    traffic_light || abort 1 "traffic light: red"
+
 	    unzip -t $workBatch  >/dev/null 2>&1
 	    if [ $? -ne 0 ] ; then
 		warn "integrity problem with $workBatch - move it to ${workBatch}.err"
@@ -179,6 +185,10 @@ run_spool(){ # max_jobs_to_submit, max_jobs_perStudy, specific_study
 
     # main loop
     for workdir in ${allWorkDirs} ; do
+
+	nForeseen=0
+	traffic_light || abort 1 "traffic light: red"
+
         ! ${lMaxJobsPerStudy} || local __StudyComplete=0
 	#check for desc files in the current work dir, and subfolders
 	# take into account arrival time
@@ -230,81 +240,82 @@ run_spool_EOS(){
     for __tmpSourceDir in ${pathInEos} ${spooldirUpload} ; do
 
 	if [[ "${__tmpSourceDir}" == "/eos"* ]] ; then
-	    gzFiles=`eos find -name "*.tar.gz" ${__tmpSourceDir}`
+	    tarGzFiles=`eos find -name "*.tar.gz" ${__tmpSourceDir}`
 	else
-	    gzFiles=`find ${__tmpSourceDir} -mmin +5 -name "*.tar.gz"`
+	    tarGzFiles=`find ${__tmpSourceDir} -mmin +5 -name "*.tar.gz"`
 	fi
 	
 	log ".tar.gz files in ${__tmpSourceDir}:"
-	echo "${gzFiles}" | log
+	echo "${tarGzFiles}" | log
 	
-        for gzFile in ${gzFiles} ; do
+        for tmpTarGzFile in ${tarGzFiles} ; do
         
-            gzFileName=`basename ${gzFile}`
+	    nForeseen=0
+	    traffic_light || abort 1 "traffic light: red"
+
+            tarGzFileName=`basename ${tmpTarGzFile}`
 
 	    if [[ "${__tmpSourceDir}" == "/eos"* ]] ; then
-		myCommand="xrdcp --cksum adler32 ${EOS_MGM_URL}/${pathInEos}/${gzFileName} ${tmpDirBase}"
-		loopMe
-		if [ $? -ne 0 ] ; then
-        	    log "unable to download ${gzFileName} from EOS ${EOS_MGM_URL}/${pathInEos}"
-        	    continue
-		fi
+		myCommand="xrdcp --cksum adler32 ${EOS_MGM_URL}/${pathInEos}/${tarGzFileName} ${tmpDirBase}"
+		loopMe || abort 3 "unable to download ${tarGzFileName} from EOS ${EOS_MGM_URL}/${pathInEos}"
 	    else
-		myCommand="cp ${gzFile} ${tmpDirBase}"
-		loopMe
-		if [ $? -ne 0 ] ; then
-		    log "unable to download ${gzFileName} from AFS ${spooldirUpload}"
-		    continue
-		fi
+		myCommand="cp ${tmpTarGzFile} ${tmpDirBase}"
+		loopMe || abort 3 "unable to download ${tarGzFileName} from AFS ${spooldirUpload}"
 	    fi
 
-	    spool_EOS_gunzip || continue
+	    spool_EOS_gunzip || abort 3 "problem in gunzipping ${tarGzFileName} - better not to screw up disk quota"
 		
-	    tarFile=${tmpDirBase}/${gzFileName%.gz}
-	    spool_EOS_untar || continue
+	    tarFile=${tmpDirBase}/${tarGzFileName%.gz}
+	    spool_EOS_untar || abort 3 "problem in untaring ${tarFile} - better not to screw up disk quota"
 	    
 	    spool_EOS_descfiles
 		
 	    # clean
 	    if [[ "${__tmpSourceDir}" == "/eos"* ]] ; then
-		eos rm ${pathInEos}/${gzFileName}
+		eos rm ${pathInEos}/${tarGzFileName}
 	    else
-		rm ${gzFile}
+		rm ${tmpTarGzFile}
 	    fi
-	    rm ${tarFile}
+
         done
 
     done
 }
 
 function spool_EOS_gunzip(){
-    myCommand="gunzip ${tmpDirBase}/${gzFileName}"
+    myCommand="gunzip -f ${tmpDirBase}/${tarGzFileName}"
     if loopMe ; then
 	return 0
     else
-        log "unable to gunzip ${gzFileName}"
-	rm ${tmpDirBase}/${gzFileName}
+	reportMsg="unable to gunzip ${tarGzFileName}"
+        log ${reportMsg}
         return 1
     fi
 }
 
 function spool_EOS_untar(){
     nForeseen=`tar -tvf ${tarFile} | wc -l`
-    # tar -tvf always returns a '.'
-    nForeseen=$(( $nForeseen -1 ))
-    if traffic_light ; then
-	myCommand="tar -xvf ${tarFile} -C ${tmpDirBase}"
-	loopMe
-	if [ $? -ne 0 ] ; then
-            log "unable to untar ${tarFile}"
-	    rm ${tarFile}
-            return 1
-	fi
+    if [ ${nForeseen} -eq 1 ] ; then
+	reportMsg="tar file contains only one file!"
+        log ${reportMsg}
+        local __lerr=1
     else
-	rm ${tarFile}
-        return 2
+	if traffic_light ; then
+	    myCommand="tar -xf ${tarFile} -C ${tmpDirBase}"
+	    if loopMe ; then
+		local __lerr=0
+	    else
+		rm *.desc *.zip
+		reportMsg="unable to untar ${tarFile}"
+		log ${reportMsg}
+		local __lerr=2
+	    fi
+	else
+            local __lerr=3
+	fi
     fi
-    return 0
+    rm ${tarFile}
+    return ${__lerr}
 }
 
 spool_EOS_descfiles(){
@@ -320,28 +331,39 @@ spool_EOS_descfiles(){
 }
 
 function traffic_light(){
-    # nPresent: how many tasks presently in queue
-    # nTreated: how many tasks (factor 2 only wrt WUs) will be submitted now
+    # nPresent: how many tasks presently in queue as from server status page
+    # nTreated: how many tasks (factor 2 only wrt WUs) have been submitted so far - updated by submit_descfile
+    # nForeseen: how many tasks (factor 2 only wrt WUs) will be submitted in the present round
     # 0: green
     # 1: red
-    local __nPresentTemp=`tail -1 ${TLpath} 2> /dev/null | awk '{print ($3)}'`
-    if [ -z "${__nPresentTemp}" ] ; then
-	if [ -z "${nPresent}" ] ; then
-	    log "unable to get number of queued ${applicationDef} tasks from ${TLpath}"
-	    return 2
+    if [ -z "${nPresent}" ] ; then
+	nPresent=${currentHardLimit}
+	local __nPresentTemp=`tail -1 ${TLpath} 2> /dev/null | awk '{if (NF==5) {printf ("%.0f",1.0*$3)}}' 2> /dev/null`
+	if [ -z "${__nPresentTemp}" ] ; then
+	    if [ -z "${nPresent}" ] ; then
+		log "unable to get number of queued ${applicationDef} tasks from ${TLpath}"
+		return 2
+	    else
+		log "unable to get number of queued ${applicationDef} tasks from ${TLpath} - going on with ${nPresent}"
+	    fi
 	else
-	    log "unable to get number of queued ${applicationDef} tasks from ${TLpath} - going on with ${nPresent}"
+	    nPresent=${__nPresentTemp}
 	fi
-    else
-	nPresent=${__nPresentTemp}
     fi
-    local __nTemp=$(( ${nTreated} +${nPresent} +${nForeseen} ))
-    if [ ${__nTemp} -ge ${currentLimit} ] ; then
-	log "traffic light is red (treated+present+foreseen>limit): ${nTreated}+${nPresent}+${nForeseen}>${currentLimit}"
+    if [ ${nForeseen} -eq 0 ] ; then
+	local __currentLimit=${currentLimit}
+	local __limitText="strict_limit"
+    else
+	local __currentLimit=${currentHardLimit}
+	local __limitText="relaxed_limit"
+    fi
+    local __nTemp=$(( ${nTreated} +${nForeseen} +${nPresent} ))
+    if [ ${__nTemp} -ge ${__currentLimit} ] ; then
+	log "traffic light is red (treated+present+foreseen>${__limitText}): ${nTreated}+${nPresent}+${nForeseen}>${__currentLimit}"
 	nResidual=0
 	return 1
     else
-	log "traffic light is green (treated+present+foreseen>limit): ${nTreated}+${nPresent}+${nForeseen}<${currentLimit}"
+	log "traffic light is green (treated+present+foreseen<${__limitText}): ${nTreated}+${nPresent}+${nForeseen}<${__currentLimit}"
 	let nResidual=${currentLimit}+${__nTemp}
 	return 0
     fi
@@ -560,7 +582,7 @@ function loopMe(){
     while [ ${__reply} -ne 0 ] && [ ${__iTrials} -lt ${nMaxRetrial} ] ; do
         let __iTrials+=1
         log "command: ${myCommand} - run at `date` - trial ${__iTrials}"
-        ${myCommand}
+        ${myCommand} 2>&1 | log
         __reply=$?
     done
     if [ ${__reply} -ne 0 ] ; then
@@ -574,9 +596,13 @@ cat <<EOF
 Usage: $(basename $0) [options]
 
         Where options are:
+        -d study_name   - submit only tasks of study_name
         -h              - print usage and exit
+        -m number       - set max no of jobs per study to submit
         -n number       - set max no of jobs to submit this run
 	-k		- Keep .desc.done and .zip contents
+
+        All options but -k do not apply to EOS spooldir
 
 EOF
 }
@@ -627,47 +653,58 @@ nResidual=0
 # log find ${spooldir} -mindepth 3 -maxdepth 3 -mtime +1 -type d -empty -delete -print
 # find ${spooldir} -mindepth 3 -maxdepth 3 -mtime +1 -type d -empty -delete -print | log
 
-# traffic light
+# init traffic light
 currentLimit=`grep -v '#' ${boincdir}/queue_thresholds.txt | awk -v "appName=${applicationDef}" '{if ($1==appName) {print ($2)}}' | tail -1`
 if [ -z "${currentLimit}" ] ; then
-    abort 1 "unable to get threshold of queued ${applicationDef} tasks from ${boincdir}/queue_thresholds.txt"
+    abort 4 "unable to get threshold of queued ${applicationDef} tasks from ${boincdir}/queue_thresholds.txt"
 fi
+currentTolerance=`grep -v '#' ${boincdir}/queue_thresholds.txt | awk -v "appName=${applicationDef}" '{if ($1==appName) {print ($3)}}' | tail -1`
+if [ -z "${currentTolerance=}" ] ; then
+    abort 4 "unable to get tolerance on threshold of queued ${applicationDef} tasks from ${boincdir}/queue_thresholds.txt"
+fi
+let currentHardLimit=${currentLimit}+${currentTolerance}
 nTreated=0
 nForeseen=0
 traffic_light || abort 1 "traffic light: red"
 
 if ! [ -d ${tmpDirBase} ] ; then
-    mkdir -p ${tmpDirBase}
-    if [ $? -ne 0 ] ; then
-	abort 1 "problems in creating ${tmpDirBase} - cannot proceed"
-    fi
+    mkdir -p ${tmpDirBase} || abort 5 "problems in creating ${tmpDirBase} - cannot proceed"
 fi
 origPath=${tmpDirBase}
 log "remaining .tar.gz files in ${tmpDirBase} from previous run"
-for gzFile in `find ${tmpDirBase} -name "*.tar.gz"` ; do
-    gzFileName=`basename ${gzFile}`
-    spool_EOS_gunzip || continue
-    tarFile=${tmpDirBase}/${gzFileName%.gz}
-    spool_EOS_untar || continue
+for tmpTarGzFile in `find ${tmpDirBase} -name "*.tar.gz"` ; do
+    tarGzFileName=`basename ${tmpTarGzFile}`
+    spool_EOS_gunzip || abort 5 "problem in gunzipping ${tarGzFileName} - better not to screw up disk quota"
+    tarFile=${tmpDirBase}/${tarGzFileName%.gz}
+    spool_EOS_untar || abort 5 "problem in untaring ${tarFile} - better not to screw up disk quota"
     spool_EOS_descfiles
-    rm ${tarFile}
+    # clean
+    eos ls -1 ${pathInEos}/${tarGzFileName} 2>&1 > /dev/null
+    if [ $? -eq 0 ] ; then
+	log "eos rm ${pathInEos}/${tarGzFileName}" 
+	eos rm ${pathInEos}/${tarGzFileName}
+    fi
+    ls -1 ${pathInEos}/${tarGzFileName} 2>&1 > /dev/null
+    if [ $? -eq 0 ] ; then
+	log "rm ${spooldirUpload}/${tarGzFileName}"
+	rm ${spooldirUpload}/${tarGzFileName}
+    fi
 done
 log "remaining .tar files in ${tmpDirBase} from previous run"
 for tarFile in `find ${tmpDirBase} -name "*.tar"` ; do
-    spool_EOS_untar || continue
+    spool_EOS_untar || abort 5 "problem in untaring ${tarFile} - better not to screw up disk quota"
     spool_EOS_descfiles
-    rm ${tarFile}
 done
 log "remaining .desc files in ${tmpDirBase} from previous run"
 spool_EOS_descfiles
 
 log run_spool_EOS
 run_spool_EOS
-
-if [ ${nResidual} -gt 0 ] && [ ${maxjobs} -gt ${nResidual} ] ; then
-    log "updating maxjobs from ${maxjobs} to ${nResidual} following limit on max number or queued tasks at ${currentLimit}"
-    maxjobs=${nResidual}
-fi
+ 
+# if [ ${nResidual} -gt 0 ] && [ ${maxjobs} -gt ${nResidual} ] ; then
+#     log "updating maxjobs from ${maxjobs} to ${nResidual} following limit on max number or queued tasks at ${currentLimit}"
+#     maxjobs=${nResidual}
+# fi
 # log run_spool $maxjobs $maxjobs_perStudy $studyName
 # run_spool $maxjobs $maxjobs_perStudy $studyName
 

--- a/boinc_software/cronjobs/cron.submit-simo3
+++ b/boinc_software/cronjobs/cron.submit-simo3
@@ -272,6 +272,7 @@ run_spool_EOS(){
 		
 	    # clean
 	    if [[ "${__tmpSourceDir}" == "/eos"* ]] ; then
+		log "eos rm ${pathInEos}/${tarGzFileName}"
 		eos rm ${pathInEos}/${tarGzFileName}
 	    else
 		rm ${tmpTarGzFile}

--- a/boinc_software/cronjobs/mv2EOS.sh
+++ b/boinc_software/cronjobs/mv2EOS.sh
@@ -120,7 +120,7 @@ makeTar(){
 	tarName=`basename ${spooldir}`_`date "+%Y-%m-%d_%H-%M-%S".tar`
 	log "new tar name: ${tarName}"
 
-	myCommand="tar -cvf ../${tarName} ."
+	myCommand="tar -cvf ../${tarName} *.desc *.zip"
 	log "${myCommand}"
 	${myCommand}
     else
@@ -184,7 +184,7 @@ EOF
 
 maxjobs=0 # =0: no limits
 maxjobs_perStudy=1000
-maxjobs_perTar=10000
+maxjobs_perTar=10000 # WUs
 studyName=""
 
 while getopts ":hd:m:n:N:"  OPT

--- a/boinc_software/cronjobs/zip-trashed-WUs.sh
+++ b/boinc_software/cronjobs/zip-trashed-WUs.sh
@@ -107,11 +107,9 @@ function mvZip(){
     log "...cp ${__fileToCopy} ${__destPath}"
     cp ${__fileToCopy} ${__destPath}
     if [ $? -eq 0 ] ; then
-        if [[ "${__fileToCopy}" != "${tmpDirBase}"* ]] ; then
-            # in case of zip in a subfolder of ${tmpDirBase}, there is no
-	    #    need to clean away, as cleaning will be performed at the end
-	    rm -f ${__fileToCopy}
-	fi
+	# rm zip file
+	log "...cleaning: rm -f ${__fileToCopy}"
+	rm -f ${__fileToCopy}
     else
         if [[ "${__fileToCopy}" == "${tmpDirBase}"* ]] ; then
             # in case of zip in a subfolder of ${tmpDirBase}, copy it here
@@ -157,9 +155,18 @@ function actualZip(){
     cd ${__tmpDir}
     zip ${__zipFileName} ${tmpWUnames} 2>&1 | log
     local __zipStatus=$?
-    cd ${__currDir}
+    # rm result files in ${__tmpDir}
     if ! ${lTest} ; then
 	if [ ${__zipStatus} -eq 0 ] ; then
+	    log "...cleaning results just zipped in ${__tmpDir}"
+	    rm ${tmpWUnames}
+	fi
+    fi
+    cd ${__currDir}
+    # rm result files in ${__currDir}
+    if ! ${lTest} ; then
+	if [ ${__zipStatus} -eq 0 ] ; then
+	    log "...cleaning original results in ${__currDir}"
 	    rm ${tmpWUnames}
 	fi
     fi

--- a/boinc_software/maintain_EOS_spooldir/inspectTars.sh
+++ b/boinc_software/maintain_EOS_spooldir/inspectTars.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+
+# please use it as:
+#     ./inspectTars.sh 2>&1 | tee -a inspectTars.sh.log
+
+export EOS_MGM_URL=root://eosuser.cern.ch
+eospath=/eos/user/s/sixtadm/spooldirs/uploads/boinc
+# regexp: no wildcards!!!!!
+regexp="workspace1_HEL_Qp_2_MO_0_1t_3s_1e7turns"
+regexp="workspace2_lhc2017_c14_o20_N"
+nMaxRetrial=10
+lFilter=true
+lCorrectStructure=true
+
+tmpDir="/tmp/sixtadm/`basename $0`"
+[ -d ${tmpDir} ] || mkdir ${tmpDir}
+
+function loopMe(){
+    # myCommand should be defined before the call
+    local __reply=1
+    local __iTrials=0
+    while [ ${__reply} -ne 0 ] && [ ${__iTrials} -lt ${nMaxRetrial} ] ; do
+        let __iTrials+=1
+        log "command: ${myCommand} - run at `date` - trial ${__iTrials}"
+        ${myCommand}
+        __reply=$?
+    done
+    if [ ${__reply} -ne 0 ] ; then
+        log " ...giving up on command."
+    fi
+    return ${__reply}
+}
+
+function log(){
+    echo "$(date -Iseconds) $*"
+}
+
+if ${lFilter} ; then
+    log "looking for ${regexp} in .tar.gz files in ${eospath} ..."
+    totalRemoved=0
+    trap "log \"killed \${totalRemoved} WUs in total\"" exit
+fi
+
+log "scanning `eos ls -1 "${eospath}/*.tar.gz" | wc -l` .tar.gz files ..."
+cd ${tmpDir}
+
+for tmpTarGz in `eos ls -1 "${eospath}/*.tar.gz"` ; do
+    log "checking ${eospath}/${tmpTarGz} ..."
+    lTreated=false
+    tmpTar=${tmpTarGz%.gz}
+
+    log " ...downloading from EOS ..."
+    myCommand="xrdcp -f --cksum adler32 ${EOS_MGM_URL}/${eospath}/${tmpTarGz} ."
+    loopMe
+    oldDim=`ls -ltrh ${tmpTarGz}`
+
+    log " ...gunzipping ..."
+    myCommand="gunzip ${tmpTarGz}"
+    loopMe
+    cp ${tmpTar} orig1.tar
+        
+    if ${lCorrectStructure} ; then
+
+        log " ...counting number of files contained in ${tmpTar}"
+        nFiles=`tar -tvf ${tmpTar} | wc -l`
+        log "    ...contains ${nFiles} file(s)"
+
+        if [ ${nFiles} -eq 1 ] ; then
+        	log "    ...restoring regular structure:"
+        
+        	log "       extract .tar.gz from .tar..."
+        	myCommand="tar -xvf ${tmpTar}"
+        	loopMe
+        	rm ${tmpTar}
+        
+        	log "       extract all .desc and .zip from .tar.gz ..."
+        	myCommand="tar -xvzf ${tmpTarGz}"
+        	loopMe
+        	rm ${tmpTarGz} 
+        
+        	log "       tar all .desc and .zip into new .tar file..."
+        	myCommand="tar -cvf ${tmpTar} *.desc *.zip"
+        	loopMe
+        	rm -f *.desc *.zip
+        
+		lTreated=true
+
+        elif [ $((${nFiles} % 2)) -eq 1 ] ; then
+        	log "    ...odd number of files: suspect..."
+        
+        	log "       extract all .desc and .zip from .tar ..."
+        	myCommand="tar -xvf ${tmpTar}"
+        	loopMe
+        	rm ${tmpTar}
+        
+        	log "       tar all .desc and .zip into new .tar file..."
+        	myCommand="tar -cvf ${tmpTar} *.desc *.zip"
+        	loopMe
+        	rm -f *.desc *.zip
+
+		lTreated=true
+
+        else
+        	log "    ...everything is fine."
+        fi
+    fi
+
+    cp ${tmpTar} orig2.tar
+
+    if ${lFilter} ; then
+        log " ...finding instances of ${regexp} in ${tmpTar}"
+	WUs=`tar -tvf ${tmpTar} | grep ${regexp}`
+	if [ -n "${WUs}" ] ; then
+    	    nInstances=`echo "${WUs}" | wc -l | awk '{print ($1/2)}'`
+    	    log "...found ${nInstances} instances of searched regexp"
+    	    log "...removing files:"
+    	    myCommand="tar -vf ${tmpTar} --delete "'*'"${regexp}"'*'
+	    loopMe
+
+    	    let totalRemoved=${totalRemoved}+${nInstances}
+    	    log "...removed:"
+    	    echo "${WUs}" | grep .desc
+
+	    lTreated=true
+	fi
+    fi
+
+    log "    ...gzipping..."
+    myCommand="gzip ${tmpTar}"
+    loopMe
+
+    log "    ...new dimension:"
+    log `ls -ltrh ${tmpTarGz}`
+    log "    ...old dimension:"
+    log "${oldDim}"
+
+    log "    ...quick checks"
+    log "       tar -tvzf ${tmpTarGz} | wc -l : `tar -tvzf ${tmpTarGz} | wc -l`"
+    log "       tar -tvzf ${tmpTarGz} | grep ${regexp} | wc -l : `tar -tvzf ${tmpTarGz} | grep ${regexp} | wc -l`"
+    log "       tar -tvzf orig2.tar | wc -l : `tar -tvf orig2.tar | wc -l`"
+    log "       tar -tvzf orig2.tar | grep ${regexp} | wc -l : `tar -tvf orig2.tar | grep ${regexp} | wc -l`"
+
+    log "    ...copying ${tmpTarGz} back to EOS..."
+    myCommand="xrdcp -f --cksum adler32 ${tmpTarGz} ${EOS_MGM_URL}/${eospath}/"
+    log "${myCommand}"
+
+    ans='p'
+    while [ ${ans} != "y" ] && [ ${ans} != "n" ] ; do
+	log " shall I proceed with copying back to / cleaning away file from EOS? [y/n]"
+	read ans
+    done
+
+    if [ ${ans} == "y" ] ; then
+	log " proceed"
+	if [ `tar -tvzf ${tmpTarGz} | wc -l` -eq 0 ] ; then
+	    log " no need of copying back to EOS but removing original file"
+	    myCommand="eos rm ${eospath}/${tmpTarGz}"
+	    loopMe
+	else
+	    # xrdcp
+	    loopMe
+	fi
+    else
+	log " going on with next .tar.gz"
+    fi
+    log " cleaning tmp ${tmpDir} "
+    rm orig?.tar ${tmpTarGz}
+
+done
+
+cd - 2>&1 . /dev/null
+log ...ended by `date`
+


### PR DESCRIPTION
This PR aims at fixing non-optimal configurations of sixtadm acrontab jobs on `boincai11.cern.ch`.

Recently, it happened (twice) that the server was experiencing a saturation of the `/tmp` folder - the issue was reported twice to IT: [https://cern.service-now.com/service-portal/view-incident.do?n=INC2206821](INC2206821) and [https://cern.service-now.com/service-portal/view-request.do?n=RQF1475624](RQF1475624).

After looking more carefully at the code of the acrontab jobs, I realised that:
* the script zipping results study by study and making them available on the AFS spooldir was cleaning away the `/tmp` folder only at the end of the overall processing, not on a study-by-study basis. This has now been fixed, and both result files and `.zip` files are removed after zipping;
* the script submitting work to the boinc server was continuing to the next `.tar` or `.tar.gz` file in case of errors, without removing the erroring archive from `/tmp`. Now, the script aborts immediately, with a notification email immediately sent to sixtadm mail box;
* the script for removing jobs from `.tar.gz` files still in EOS was re-generating files that contained the `.tar` archive, which contained again a `.tar.gz` file, which was not treated regularly. The anomaly is now caught and a notification sent to sixtadm email box. At the same time, the proper command has been implemented in the cleaning script - in addition to the machinery for restoring the usual structure of the `.tar.gz` files on EOS.

The PR comes also with minor adjustments to the concerned scripts, in terms of comments and printout.

By amereghe as sixtadm.