### PR TITLE
Adding reporting of WUs behind traffic light, i.e. still in EOS, waiting for being queued on BOINC

### DIFF
--- a/boinc_software/monitor-boinc-server/general-activity/parseStudyStates.py
+++ b/boinc_software/monitor-boinc-server/general-activity/parseStudyStates.py
@@ -1,20 +1,29 @@
 #!/usr/bin/python
 
 if ( __name__ == "__main__" ):
+    import sys
 
     iFileName="all_WUs.txt"
     oFileName="studies.txt"
+    if ( len(sys.argv)<3):
+        print " usage: %s [inputFileName] [outputFileName]"%(sys.argv[0])
+        exit(1)
+    else:
+        iFileName=sys.argv[1]
+        oFileName=sys.argv[2]
     lPrintAssimilateState=False
 
     print "parsing %s file..."%(iFileName)
+    # data structure:
+    #   studiesStates[<studyName>]["assimilate_state"][<assimilateStateID>]=N
     studiesStates={}
     headers=None
     with open(iFileName,'r') as iFile:
         for line in iFile.readlines():
-            if ( "name" in line and "assimilate_state" in line):
+            if ( "name" in line and "assimilate_state" in line): # table header
                 headers=line.split()
                 continue
-            elif ( line.startswith("now:") ):
+            elif ( line.startswith("now:") ): # timestamp
                 now=line[len("now:"):].strip()
                 continue
             if (headers is None):
@@ -27,7 +36,7 @@ if ( __name__ == "__main__" ):
                         studiesStates[studyName]={}
                         studiesStates[studyName]['assimilate_state']={}
                 elif(fieldName=="assimilate_state"):
-                    assimilate_state=int(float(datum))
+                    assimilate_state=int(float(datum)+1E-04)
                     if (not studiesStates[studyName]['assimilate_state'].has_key(datum)):
                         studiesStates[studyName]['assimilate_state'][datum]=0
             studiesStates[studyName]['assimilate_state']['%1i'%(assimilate_state)]+=1
@@ -46,14 +55,14 @@ if ( __name__ == "__main__" ):
                 if ( not studiesStates[studyName]['assimilate_state'].has_key(tmpState) ):
                     studiesStates[studyName]['assimilate_state'][tmpState]=0
         with open(oFileName,'w') as oFile:
-            oFile.write("# found %i studies\n"%(len(studiesStates)))
+            oFile.write("# found %i studies in BOINC DB\n"%(len(studiesStates)))
             oFile.write("# status at %s\n"%(now))
-            strOut="# %-58s,"%("study name")
+            strOut="# %-68s,"%("study name")
             if (lPrintAssimilateState): strOut+=", ".join( "assimilate_state=%1s"%(key) for key in sorted(allStates) )+", "
             strOut+="%18s, %14s, %18s" %("total","assimilated [%]", "prog./queue [%]")
             oFile.write('%s\n'%(strOut))
             for studyName in sorted(studiesStates.keys()):
-                strOut="%-60s"%(studyName)
+                strOut="%-70s"%(studyName)
                 if (lPrintAssimilateState): strOut+=" ".join( ( "%19i"%(studiesStates[studyName]['assimilate_state'][key]) for key in sorted(allStates) ) )
                 tot=sum(studiesStates[studyName]['assimilate_state'].values())
                 strOut+=" %18i"%(tot)

--- a/boinc_software/monitor-boinc-server/general-activity/queryStudies.sh
+++ b/boinc_software/monitor-boinc-server/general-activity/queryStudies.sh
@@ -2,9 +2,14 @@
 
 lQuery=true
 lPython=true
+lTrafficLight=true
 
-oFile=all_WUs.txt
-passWd=`cat ~/private/.mySQLcred`
+oFileBOINCdb=all_WUs.txt
+oFileTrafficLight=all_trafficLight.txt
+oStudyFile=studies.txt
+eosSpoolDirs=(
+    /eos/user/s/sixtadm/spooldirs/uploads/boinc
+)
 
 now=`date '+%F %T'`
 
@@ -13,18 +18,36 @@ echo "starting at ${now} ..."
 
 if ${lQuery} ; then
     echo "   querying the database ..."
-    echo "now: ${now}"> ${oFile}
-    mysql -h dbod-sixtrack.cern.ch -u sixtadm --password="${passWd}" -P 5513 -Dsixt_production -e"select name,assimilate_state from workunit where appid=1 or appid=10;"  >> ${oFile}
+    echo "now: ${now}"> ${oFileBOINCdb}
+    mysql -h dbod-sixtrack.cern.ch -u sixtadm -P 5513 -Dsixt_production -e"select name,assimilate_state from workunit where appid=1 or appid=10;"  >> ${oFileBOINCdb}
     echo "   ...done."
 fi
 
 if ${lPython} ; then
     echo "   parsing results..."
-    python parseStudyStates.py
-    if [ $? -eq 0 ] ; then
-	rm all_WUs.txt
-    fi
+    python parseStudyStates.py ${oFileBOINCdb} ${oStudyFile}
+    [ $? -ne 0 ] || rm ${oFileBOINCdb}
     echo "   ...done."
+fi
+
+if ${lTrafficLight} ; then
+    echo "looking at WUs behind traffic light..."
+    for eosSpoolDir in ${eosSpoolDirs[@]} ; do
+	echo "...spooldir ${eosSpoolDir} ..."
+    	for tmpFile in `ls -1 ${eosSpoolDir}/*.tar.gz` ; do
+	    echo "   ...archive `basename ${tmpFile}` ..."
+    	    tar -tvzf ${tmpFile} "*.zip" | awk '{print ($6)}' | awk 'BEGIN{FS="__"}{print ($1)}' | sort | uniq -c >> ${oFileTrafficLight}
+    	done
+    done
+    echo "...summarising..."
+    echo "" >> ${oStudyFile}
+    echo "" >> ${oStudyFile}
+    echo "# status of traffic light" >> ${oStudyFile}
+    printf "# %-68s %18s\n" "study name" "tot WUs" >> ${oStudyFile}
+    cat ${oFileTrafficLight} | sort -k2 | awk '{if ($2!=CurrName) {if (NR>1) { printf("%-70s %18i TL\n",CurrName,tot) }; CurrName=$2; tot=0}; tot+=$1}END{if (NR>1) { printf("%-70s %18i TL\n",CurrName,tot)}}' >> ${oStudyFile}
+    echo "...cleaning..."
+    rm ${oFileTrafficLight}
+    echo "...traffic light done."
 fi
 
 now=`date '+%F %T'`


### PR DESCRIPTION
This PR aims at implementing a regular reporting of the status of WUs behind the traffic light, i.e. waiting in the EOS spooldir for being actually queued to BOINC. The buffer space on EOS was deemed necessary to not have a huge backlog of SixTrack tasks on the BOINC server, leading to slow BOINC DB performances; EOS was chosen because of its large capacity and the good performances as storage of large files (`.tar.gz`).

The status of the WUs behind the traffic light is appended to the report contained in the file `studies.txt`, in `boinc_software/monitor-boinc-server/general-activity`. Study by study, the total number of WUs still waiting to be queued on the BOINC server is reported, along with a `TL` flag (traffic light), such that when grepping the file the user see a clear distinction between WUs already queued / being crunched and those still behind the traffic light. For instance:
```
grep -e '#' -e workspace2_lhc2017_c14_o20_N1.4_e2.2 studies.txt 
# found 208 studies in BOINC DB
# status at 2019-12-12 12:24:17
# study name                                                          ,             total, assimilated [%],    prog./queue [%]
workspace2_lhc2017_c14_o20_N1.4_e2.2                                                 1190           97.899               2.101
# status of traffic light
# study name                                                                      tot WUs
workspace2_lhc2017_c14_o20_N1.4_e2.2                                                   26 TL
```
shows that there are 1190 WUs of the grepped study in the BOINC DB, out of which 2.1 % still being crunched (the rest has been already assimilated), and 26 still behind the traffic light.

In addition:
* no longer reading BOINC DB password from local (hidden) file;
* I/O files of `parseStudyStates.py` as terminal-line arguments;
* minor changes to `parseStudyStates.py`.

By @amereghe as @sixtadm .